### PR TITLE
Rename storage/auth to storage/token

### DIFF
--- a/src/state/github.ts
+++ b/src/state/github.ts
@@ -3,9 +3,9 @@ import { observable } from "mobx";
 import { Repo } from "../github/api/repos";
 import { loadAuthenticatedUser, User } from "../github/api/user";
 import {
-  getGitHubApiToken as loadApiTokenFromStorage,
-  updateGitHubApiToken as saveGitHubTokenToStorage
-} from "./storage/auth";
+  loadApiTokenFromStorage,
+  saveApiTokenToStorage
+} from "./storage/token";
 
 export class GitHubState {
   private octokit: Octokit | null = null;
@@ -42,7 +42,7 @@ export class GitHubState {
       kind: "provided",
       token
     };
-    await saveGitHubTokenToStorage(token);
+    await saveApiTokenToStorage(token);
   }
 }
 

--- a/src/state/storage/token.ts
+++ b/src/state/storage/token.ts
@@ -3,7 +3,7 @@ import { chromeApi } from "../../chrome";
 /**
  * Returns the GitHub API token stored in settings.
  */
-export async function getGitHubApiToken(): Promise<string | null> {
+export async function loadApiTokenFromStorage(): Promise<string | null> {
   return new Promise<string | null>(resolve => {
     chromeApi.storage.local.get(["gitHubApiToken"], result => {
       resolve(result.gitHubApiToken || null);
@@ -14,7 +14,7 @@ export async function getGitHubApiToken(): Promise<string | null> {
 /**
  * Updates the GitHub API token in settings.
  */
-export function updateGitHubApiToken(token: string) {
+export function saveApiTokenToStorage(token: string) {
   return new Promise<string>(resolve => {
     chromeApi.storage.local.set(
       {


### PR DESCRIPTION
This also renames functions to match the imports in GitHubState.