### PR TITLE
Move all state to GitHubState

### DIFF
--- a/src/background/check-pull-requests.ts
+++ b/src/background/check-pull-requests.ts
@@ -1,84 +1,44 @@
-import { chromeApi } from "../chrome";
 import { PullRequest } from "../github/api/pull-requests";
 import { loadPullRequestsRequiringReview } from "../github/loader";
-import { TokenValue } from "../state/github";
+import { store } from "../state/store";
 import { showBadgeError, updateBadge } from "./badge";
 import { showNotification } from "./notifications";
 
 /**
  * Checks if there are any new pull requests and notifies the user when required.
  */
-export async function checkPullRequests(tokenValue: TokenValue) {
-  if (tokenValue.kind !== "provided") {
-    return;
-  }
+export async function checkPullRequests() {
   let error;
   try {
+    await store.github.start();
+    if (store.github.tokenValue.kind !== "provided") {
+      return;
+    }
     const unreviewedPullRequests = await loadPullRequestsRequiringReview(
-      tokenValue.token
+      store.github.tokenValue.token
     );
-    await saveUnreviewedPullRequests(unreviewedPullRequests);
-    await updateBadge(unreviewedPullRequests.size);
+    await store.github.setUnreviewedPullRequests(unreviewedPullRequests);
+    await updateBadge(unreviewedPullRequests.length);
     await showNotificationForNewPullRequests(unreviewedPullRequests);
     error = null;
   } catch (e) {
     error = e;
     await showBadgeError();
   }
-  chromeApi.storage.local.set({
-    error: error ? error.message : null
-  });
-}
-
-/**
- * Saves the list of unreviewed pull requests so that they can be shown in the popup.
- */
-async function saveUnreviewedPullRequests(pullRequests: Set<PullRequest>) {
-  await new Promise(resolve => {
-    chromeApi.storage.local.set(
-      {
-        unreviewedPullRequests: Array.from(pullRequests)
-      },
-      resolve
-    );
-  });
+  store.github.setError(error ? error.message : null);
 }
 
 /**
  * Shows a notification for each pull request that we haven't yet notified about.
  */
-async function showNotificationForNewPullRequests(
-  pullRequests: Set<PullRequest>
-) {
-  const lastSeenPullRequestUrls = new Set(await getLastSeenPullRequestsUrls());
+async function showNotificationForNewPullRequests(pullRequests: PullRequest[]) {
   for (const pullRequest of pullRequests) {
-    if (!lastSeenPullRequestUrls.has(pullRequest.html_url)) {
+    if (!store.github.lastSeenPullRequestUrls.has(pullRequest.html_url)) {
       console.log(`Showing ${pullRequest.html_url}`);
       showNotification(pullRequest);
     } else {
       console.log(`Filtering ${pullRequest.html_url}`);
     }
   }
-  recordSeenPullRequests(pullRequests);
-}
-
-/**
- * Records the pull requests we saw this time, so that we don't show a notification
- * next time.
- */
-async function recordSeenPullRequests(pullRequests: Set<PullRequest>) {
-  chromeApi.storage.local.set({
-    lastSeenPullRequests: Array.from(pullRequests).map(p => p.html_url)
-  });
-}
-
-/**
- * Returns a list of pull request URLs that required attention last time we checked.
- */
-function getLastSeenPullRequestsUrls(): Promise<string[]> {
-  return new Promise(resolve => {
-    chromeApi.storage.local.get(["lastSeenPullRequests"], result => {
-      resolve(result.lastSeenPullRequests || []);
-    });
-  });
+  store.github.setLastSeenPullRequests(pullRequests);
 }

--- a/src/background/entry.ts
+++ b/src/background/entry.ts
@@ -1,5 +1,4 @@
 import { chromeApi } from "../chrome";
-import { store } from "../state/store";
 import { checkPullRequests } from "./check-pull-requests";
 import { onNotificationClicked } from "./notifications";
 
@@ -34,10 +33,5 @@ chromeApi.runtime.onInstalled.addListener(triggerRefresh);
 chromeApi.notifications.onClicked.addListener(onNotificationClicked);
 
 async function triggerRefresh() {
-  try {
-    const tokenValue = await store.github.fetchSignedInUser();
-    await checkPullRequests(tokenValue);
-  } catch (e) {
-    console.error(e);
-  }
+  checkPullRequests().catch(console.error);
 }

--- a/src/components/Popup.css
+++ b/src/components/Popup.css
@@ -14,7 +14,7 @@ a {
   text-decoration: none;
 }
 
-.pull-requests .error {
+.error {
   border: 1px solid #d00;
   background: #fdd;
   color: #400;

--- a/src/github/loader.ts
+++ b/src/github/loader.ts
@@ -9,7 +9,7 @@ import { loadAuthenticatedUser } from "./api/user";
  */
 export async function loadPullRequestsRequiringReview(
   token: string
-): Promise<Set<PullRequest>> {
+): Promise<PullRequest[]> {
   console.log("Loading pull requests...");
   const octokit = new Octokit({
     auth: `token ${token}`
@@ -46,7 +46,7 @@ export async function loadPullRequestsRequiringReview(
     `Found ${anotherReview.length} pull request(s) requiring another review.`
   );
 
-  return new Set(firstReview.concat(anotherReview));
+  return [...new Set(firstReview.concat(anotherReview))];
 }
 
 /**

--- a/src/state/github.ts
+++ b/src/state/github.ts
@@ -1,7 +1,14 @@
 import Octokit from "@octokit/rest";
 import { observable } from "mobx";
-import { Repo } from "../github/api/repos";
+import { PullRequest } from "../github/api/pull-requests";
 import { loadAuthenticatedUser, User } from "../github/api/user";
+import { loadErrorFromStorage, saveErrorToStorage } from "./storage/error";
+import {
+  loadLastSeenPullRequestsUrlsFromStorage,
+  loadUnreviewedPullRequestsFromStorage,
+  saveSeenPullRequestsToStorage,
+  saveUnreviewedPullRequestsToStorage
+} from "./storage/pull-requests";
 import {
   loadApiTokenFromStorage,
   saveApiTokenToStorage
@@ -14,10 +21,42 @@ export class GitHubState {
     kind: "loading"
   };
   @observable user: User | null = null;
-  @observable repos: Repo[] | null = [];
+  @observable unreviewedPullRequests: PullRequest[] | null = null;
+  @observable lastSeenPullRequestUrls = new Set<string>();
+  @observable lastError: string | null = null;
 
-  async fetchSignedInUser() {
+  async start() {
     const token = await loadApiTokenFromStorage();
+    this.lastError = await loadErrorFromStorage();
+    await this.load(token);
+  }
+
+  async setError(error: string | null) {
+    this.lastError = error;
+    await saveErrorToStorage(error);
+  }
+
+  async setNewToken(token: string) {
+    this.tokenValue = {
+      kind: "provided",
+      token
+    };
+    await saveApiTokenToStorage(token);
+    await this.setError(null);
+    await this.load(token);
+  }
+
+  async setUnreviewedPullRequests(pullRequests: PullRequest[]) {
+    this.unreviewedPullRequests = pullRequests;
+    await saveUnreviewedPullRequestsToStorage(pullRequests);
+  }
+
+  async setLastSeenPullRequests(pullRequests: PullRequest[]) {
+    this.lastSeenPullRequestUrls = new Set(pullRequests.map(p => p.html_url));
+    await saveSeenPullRequestsToStorage(this.lastSeenPullRequestUrls);
+  }
+
+  private async load(token: string | null) {
     if (token) {
       this.tokenValue = {
         kind: "provided",
@@ -27,22 +66,16 @@ export class GitHubState {
         auth: `token ${token}`
       });
       this.user = await loadAuthenticatedUser(this.octokit);
+      this.unreviewedPullRequests = await loadUnreviewedPullRequestsFromStorage();
+      this.lastSeenPullRequestUrls = await loadLastSeenPullRequestsUrlsFromStorage();
     } else {
       this.tokenValue = {
         kind: "missing"
       };
-      this.octokit = null;
       this.user = null;
+      this.unreviewedPullRequests = null;
+      this.lastSeenPullRequestUrls = new Set();
     }
-    return this.tokenValue;
-  }
-
-  async setNewToken(token: string) {
-    this.tokenValue = {
-      kind: "provided",
-      token
-    };
-    await saveApiTokenToStorage(token);
   }
 }
 

--- a/src/state/storage/error.ts
+++ b/src/state/storage/error.ts
@@ -1,0 +1,26 @@
+import { chromeApi } from "../../chrome";
+
+/**
+ * Returns the last error message from storage.
+ */
+export async function loadErrorFromStorage(): Promise<string | null> {
+  return new Promise<string | null>(resolve => {
+    chromeApi.storage.local.get(["error"], result => {
+      resolve(result.error || null);
+    });
+  });
+}
+
+/**
+ * Saves the error message to storage.
+ */
+export function saveErrorToStorage(error: string | null) {
+  return new Promise<string>(resolve => {
+    chromeApi.storage.local.set(
+      {
+        error
+      },
+      resolve
+    );
+  });
+}

--- a/src/state/storage/pull-requests.ts
+++ b/src/state/storage/pull-requests.ts
@@ -1,0 +1,53 @@
+import { chromeApi } from "../../chrome";
+import { PullRequest } from "../../github/api/pull-requests";
+
+/**
+ * Saves the list of unreviewed pull requests.
+ */
+export async function saveUnreviewedPullRequestsToStorage(
+  unreviewedPullRequests: PullRequest[]
+) {
+  await new Promise(resolve => {
+    chromeApi.storage.local.set(
+      {
+        unreviewedPullRequests
+      },
+      resolve
+    );
+  });
+}
+
+export async function loadUnreviewedPullRequestsFromStorage(): Promise<
+  PullRequest[]
+> {
+  return new Promise<PullRequest[]>(resolve =>
+    chromeApi.storage.local.get(["unreviewedPullRequests"], result =>
+      resolve(result.unreviewedPullRequests || [])
+    )
+  );
+}
+
+/**
+ * Records the pull requests we saw this time, so that we don't show a notification
+ * next time.
+ */
+export async function saveSeenPullRequestsToStorage(
+  pullRequestUrls: Set<string>
+) {
+  chromeApi.storage.local.set({
+    lastSeenPullRequests: Array.from(pullRequestUrls)
+  });
+}
+
+/**
+ * Returns a list of pull request URLs that required attention last time we checked.
+ */
+export function loadLastSeenPullRequestsUrlsFromStorage(): Promise<
+  Set<string>
+> {
+  return new Promise<Set<string>>(resolve => {
+    chromeApi.storage.local.get(["lastSeenPullRequests"], result => {
+      resolve(new Set(result.lastSeenPullRequests || []));
+    });
+  });
+}


### PR DESCRIPTION
This also includes a few changes in particular:
- storing PullRequest[] instead of Set<PullRequest> to keep order in the future
- Renaming GitHubState.fetchSignedInUser() to GItHubState.load() since its responsibilities extended