### PR TITLE
Pre-fill the GitHub token description and scope

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -181,8 +181,11 @@ class Popup extends Component<PopupProps> {
         <form onSubmit={this.onSettingsSubmit}>
           <p>
             Enter a GitHub API token with <b>repo</b> scope (
-            <Link href="https://github.com/settings/tokens" target="_blank">
-              create one
+            <Link
+              href="https://github.com/settings/tokens/new?description=PR%20Monitor&amp;scopes=repo"
+              target="_blank"
+            >
+              create a new one
             </Link>
             ):
           </p>


### PR DESCRIPTION
This will lower friction for new users who don't remember to check the correct scope.