### PR TITLE
Extract Settings component out of Popup

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,21 +1,13 @@
 import styled from "@emotion/styled";
 import { observer } from "mobx-react";
-import React, { Component, FormEvent, RefObject } from "react";
-import { chromeApi } from "../chrome";
+import React, { Component } from "react";
 import { GitHubState } from "../state/github";
+import { Header } from "./design/Header";
+import { Settings } from "./Settings";
 
 export interface PopupProps {
   github: GitHubState;
 }
-
-const Header = styled.h1`
-  font-size: 14px;
-  text-align: left;
-`;
-
-const Link = styled.a`
-  text-decoration: none;
-`;
 
 const Error = styled.p`
   border: 1px solid #d00;
@@ -42,43 +34,10 @@ const PullRequestLink = styled.a`
   color: #333;
 `;
 
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-`;
-
-const TokenInput = styled.input`
-  margin-right: 8px;
-  flex-grow: 1;
-`;
-
 @observer
 class Popup extends Component<PopupProps> {
-  state: {
-    editing: boolean;
-  } = {
-    editing: false
-  };
-
-  inputRef: RefObject<HTMLInputElement>;
-
-  constructor(props: PopupProps) {
-    super(props);
-    this.inputRef = React.createRef();
-  }
-
-  async componentWillMount() {
+  async componentDidMount() {
     await this.props.github.start();
-    if (!this.props.github.token) {
-      // Automatically open the form to enter a GitHub token.
-      this.setState({
-        editing: true
-      });
-    }
-  }
-
-  componentDidMount() {
-    this.props.github.start();
   }
 
   render() {
@@ -88,7 +47,7 @@ class Popup extends Component<PopupProps> {
         {this.renderUserLogin()}
         {this.renderRepoList()}
         {this.renderPullRequestsSection()}
-        {this.renderSettingsSection()}
+        <Settings github={this.props.github} />
       </div>
     );
   }
@@ -154,79 +113,6 @@ class Popup extends Component<PopupProps> {
       </PullRequestList>
     );
   }
-
-  renderSettingsSection() {
-    return (
-      <>
-        <Header>Settings</Header>
-        {this.renderSettingsContent()}
-      </>
-    );
-  }
-
-  renderSettingsContent() {
-    if (!this.state.editing) {
-      return (
-        <p>
-          {this.props.github.token
-            ? "You have already provided a GitHub API token."
-            : "Please provide a GitHub API token."}{" "}
-          <Link href="#" onClick={this.onSettingsEditClick}>
-            Update it here.
-          </Link>
-        </p>
-      );
-    } else {
-      return (
-        <form onSubmit={this.onSettingsSubmit}>
-          <p>
-            Enter a GitHub API token with <b>repo</b> scope (
-            <Link
-              href="https://github.com/settings/tokens/new?description=PR%20Monitor&amp;scopes=repo"
-              target="_blank"
-            >
-              create a new one
-            </Link>
-            ):
-          </p>
-          <Row>
-            <TokenInput ref={this.inputRef} />
-            <button type="submit">Save</button>
-            <button onClick={this.onSettingsCancel}>Cancel</button>
-          </Row>
-        </form>
-      );
-    }
-  }
-
-  onSettingsEditClick = () => {
-    this.setState({
-      editing: true
-    });
-  };
-
-  onSettingsSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!this.inputRef.current) {
-      return;
-    }
-    const token = this.inputRef.current.value;
-    this.props.github
-      .setNewToken(token)
-      .then(() => console.log("GitHub API token updated."));
-    this.setState({
-      editing: false
-    });
-    chromeApi.runtime.sendMessage({
-      kind: "refresh"
-    });
-  };
-
-  onSettingsCancel = () => {
-    this.setState({
-      editing: false
-    });
-  };
 }
 
 export default Popup;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,118 @@
+import styled from "@emotion/styled";
+import { observer } from "mobx-react";
+import React, { Component, FormEvent, RefObject } from "react";
+import { chromeApi } from "../chrome";
+import { GitHubState } from "../state/github";
+import { Header } from "./design/Header";
+import { Link } from "./design/Link";
+
+export interface SettingsProps {
+  github: GitHubState;
+}
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const TokenInput = styled.input`
+  margin-right: 8px;
+  flex-grow: 1;
+`;
+
+@observer
+export class Settings extends Component<SettingsProps> {
+  state: {
+    editing: boolean | "default";
+  } = {
+    editing: "default"
+  };
+
+  private inputRef: RefObject<HTMLInputElement>;
+
+  constructor(props: SettingsProps) {
+    super(props);
+    this.inputRef = React.createRef();
+  }
+
+  render() {
+    return (
+      <>
+        <Header>Settings</Header>
+        {this.renderSettingsContent()}
+      </>
+    );
+  }
+
+  renderSettingsContent() {
+    // Show the token editing form if:
+    // - editing is "default" (user has not said whether they want to open or dismiss the form)
+    //   AND the token is not set; or
+    // - editing is explicitly set to true (user opened the form).
+    const editing =
+      this.state.editing === "default"
+        ? !this.props.github.token
+        : this.state.editing;
+    if (!editing) {
+      return (
+        <p>
+          {this.props.github.token
+            ? "You have already provided a GitHub API token."
+            : "Please provide a GitHub API token."}{" "}
+          <Link href="#" onClick={this.onSettingsEditClick}>
+            Update it here.
+          </Link>
+        </p>
+      );
+    } else {
+      return (
+        <form onSubmit={this.onSettingsSubmit}>
+          <p>
+            Enter a GitHub API token with <b>repo</b> scope (
+            <Link
+              href="https://github.com/settings/tokens/new?description=PR%20Monitor&amp;scopes=repo"
+              target="_blank"
+            >
+              create a new one
+            </Link>
+            ):
+          </p>
+          <Row>
+            <TokenInput ref={this.inputRef} />
+            <button type="submit">Save</button>
+            <button onClick={this.onSettingsCancel}>Cancel</button>
+          </Row>
+        </form>
+      );
+    }
+  }
+
+  onSettingsEditClick = () => {
+    this.setState({
+      editing: true
+    });
+  };
+
+  onSettingsSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!this.inputRef.current) {
+      return;
+    }
+    const token = this.inputRef.current.value;
+    this.props.github
+      .setNewToken(token)
+      .then(() => console.log("GitHub API token updated."));
+    this.setState({
+      editing: false
+    });
+    chromeApi.runtime.sendMessage({
+      kind: "refresh"
+    });
+  };
+
+  onSettingsCancel = () => {
+    this.setState({
+      editing: false
+    });
+  };
+}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -59,14 +59,14 @@ export class Settings extends Component<SettingsProps> {
           {this.props.github.token
             ? "You have already provided a GitHub API token."
             : "Please provide a GitHub API token."}{" "}
-          <Link href="#" onClick={this.onSettingsEditClick}>
+          <Link href="#" onClick={this.openForm}>
             Update it here.
           </Link>
         </p>
       );
     } else {
       return (
-        <form onSubmit={this.onSettingsSubmit}>
+        <form onSubmit={this.saveForm}>
           <p>
             Enter a GitHub API token with <b>repo</b> scope (
             <Link
@@ -80,20 +80,20 @@ export class Settings extends Component<SettingsProps> {
           <Row>
             <TokenInput ref={this.inputRef} />
             <button type="submit">Save</button>
-            <button onClick={this.onSettingsCancel}>Cancel</button>
+            <button onClick={this.cancelForm}>Cancel</button>
           </Row>
         </form>
       );
     }
   }
 
-  onSettingsEditClick = () => {
+  openForm = () => {
     this.setState({
       editing: true
     });
   };
 
-  onSettingsSubmit = (event: FormEvent<HTMLFormElement>) => {
+  saveForm = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!this.inputRef.current) {
       return;
@@ -110,7 +110,7 @@ export class Settings extends Component<SettingsProps> {
     });
   };
 
-  onSettingsCancel = () => {
+  cancelForm = () => {
     this.setState({
       editing: false
     });

--- a/src/components/design/Header.tsx
+++ b/src/components/design/Header.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+
+export const Header = styled.h1`
+  font-size: 14px;
+  text-align: left;
+`;

--- a/src/components/design/Link.tsx
+++ b/src/components/design/Link.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const Link = styled.a`
+  text-decoration: none;
+`;


### PR DESCRIPTION
We take the opportunity to simplify the logic by:
- removing the state change in `componentWillMount()`, instead setting a `"default"` value for `editing`
- renaming methods to represent UI actions for clarity

This also extracts out the basic design components Header and Link.