### PR TITLE
Re-introduce persistent of the list of repositories

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -22,8 +22,8 @@ export class Popup extends Component<PopupProps> {
       <>
         <Summary github={this.props.github} />
         <Error lastError={this.props.github.lastError} />
-        {this.props.github.repoList !== null && (
-          <RepoList repos={this.props.github.repoList} />
+        {this.props.github.lastCheck !== null && (
+          <RepoList repos={this.props.github.lastCheck.repos} />
         )}
         {this.props.github.unreviewedPullRequests !== null && (
           <PullRequestList

--- a/src/components/RepoList.tsx
+++ b/src/components/RepoList.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
-import { ReposGetResponse } from "@octokit/rest";
 import { observer } from "mobx-react";
 import React, { Component } from "react";
+import { Repo } from "../state/storage/last-check";
 import { Header } from "./design/Header";
 import { List } from "./design/List";
 import { Paragraph } from "./design/Paragraph";
 
 export interface RepoListProps {
-  repos: ReposGetResponse[];
+  repos: Repo[];
 }
 
 const Repo = styled.li`
@@ -38,8 +38,8 @@ export class RepoList extends Component<RepoListProps> {
             </Paragraph>
           )}
           {this.props.repos.map(repo => (
-            <Repo key={`${repo.owner.login}/${repo.name}`}>
-              {repo.owner.login}/{repo.name}
+            <Repo key={`${repo.owner}/${repo.name}`}>
+              {repo.owner}/{repo.name}
             </Repo>
           ))}
         </List>

--- a/src/state/filtering/repos-pushed-after.ts
+++ b/src/state/filtering/repos-pushed-after.ts
@@ -1,4 +1,4 @@
-import { ReposGetResponse } from "@octokit/rest";
+import { Repo } from "../storage/last-check";
 
 /**
  * Returns a predicate that will return true if the repo was pushed after the given timestamp.
@@ -7,10 +7,10 @@ import { ReposGetResponse } from "@octokit/rest";
  */
 export function repoWasPushedAfter(
   pushedAt: string | null
-): (repo: ReposGetResponse) => boolean {
+): (repo: Repo) => boolean {
   if (!pushedAt) {
     return () => true;
   }
   const minPushedAt = new Date(pushedAt);
-  return (repo: ReposGetResponse) => new Date(repo.pushed_at) > minPushedAt;
+  return (repo: Repo) => new Date(repo.pushedAt) > minPushedAt;
 }

--- a/src/state/storage/last-check.ts
+++ b/src/state/storage/last-check.ts
@@ -1,4 +1,8 @@
-import { PullsGetResponse, PullsListResponseItem } from "@octokit/rest";
+import {
+  PullsGetResponse,
+  PullsListResponseItem,
+  ReposGetResponse
+} from "@octokit/rest";
 import {
   PullsListReviewsResponse,
   ReviewState
@@ -12,6 +16,11 @@ export const lastCheckStorage = storage<LastCheck>("lastCheck");
 
 export interface LastCheck {
   /**
+   * The list of all repositories that the user is a member of.
+   */
+  repos: Repo[];
+
+  /**
    * The list of all open pull requests across all repositories.
    *
    * This includes pull requests that the user isn't involved in (yet). We will check the
@@ -24,19 +33,22 @@ export interface LastCheck {
    * where `pushed_at` has changed since our last check.
    */
   openPullRequests: PullRequest[];
+}
 
-  /**
-   * The most recent `pushed_at` value seen across all repositories (ie the first one, since
-   * we order repositories in decreasing order).
-   *
-   * This allows us to know which repositories have not been pushed since the last check.
-   * Note that this also implies that there was no pull request either, because GitHub updates
-   * the `pushed_at` value when a pull request is created (likely because they automatically
-   * create an associated branch).
-   *
-   * This will be `null` when there were no repositories in the last check.
-   */
-  maximumPushedAt: string | null;
+export interface Repo {
+  owner: string;
+  name: string;
+
+  /** Date when the last commit was pushed (across any branch). */
+  pushedAt: string;
+}
+
+export function repoFromResponse(response: ReposGetResponse): Repo {
+  return {
+    owner: response.owner.login,
+    name: response.name,
+    pushedAt: response.pushed_at
+  };
 }
 
 export interface PullRequest {


### PR DESCRIPTION
This is now incorporated into LastCheck, so we always have a consistent last known state, and we don't need to wait for anything to load (apart from the user name).

It also allows us to remove the dependency on the ReposGetResponse type in parts of the codebase that shouldn't need to be aware of the underlying GitHub type.