### PR TITLE
Add support for Firefox

### DIFF
--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -9,12 +9,15 @@ export function showNotification(pullRequest: PullRequest) {
   // notifications about the same pull request and we can easily open a browser tab
   // to this pull request just by knowing the notification ID.
   const notificationId = pullRequest.htmlUrl;
+
+  // Chrome supports requireInteraction, but it crashes Firefox.
+  const supportsRequireInteraction = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
   chromeApi.notifications.create(notificationId, {
     type: "basic",
     iconUrl: "images/GitHub-Mark-120px-plus.png",
     title: "New pull request",
     message: pullRequest.title,
-    requireInteraction: true
+    ...(supportsRequireInteraction ? {requireInteraction: true} : {})
   });
 }
 


### PR DESCRIPTION
It turns out that Firefox supports almost the same API that Chrome offers out of the box: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Porting_a_Google_Chrome_extension.

This means that only a minor change needs to be made to enable Firefox support!

An early version is already available at https://addons.mozilla.org/en-US/firefox/addon/pr-monitor/