### PR TITLE
Add a button to mute a PR until next update

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "dependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
+    "@fortawesome/fontawesome-svg-core": "^1.2.17",
+    "@fortawesome/free-solid-svg-icons": "^5.8.1",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "mobx": "^5.9.4",
     "mobx-react": "^5.4.3",
     "react": "^16.8.6",

--- a/src/background/check-pull-requests.ts
+++ b/src/background/check-pull-requests.ts
@@ -1,7 +1,5 @@
-import { PullRequest } from "../state/storage/last-check";
+import { showBadgeError } from "../badge";
 import { store } from "../state/store";
-import { showBadgeError, updateBadge } from "./badge";
-import { showNotification } from "./notifications";
 
 /**
  * Checks if there are any new pull requests and notifies the user when required.
@@ -14,31 +12,10 @@ export async function checkPullRequests() {
       return;
     }
     await store.github.refreshPullRequests();
-    const unreviewedPullRequests = store.github.unreviewedPullRequests;
-    if (!unreviewedPullRequests) {
-      throw new Error(`Pull requests should have been loaded.`);
-    }
-    await updateBadge(unreviewedPullRequests.length);
-    await showNotificationForNewPullRequests(unreviewedPullRequests);
     error = null;
   } catch (e) {
     error = e;
     await showBadgeError();
   }
   store.github.setError(error ? error.message : null);
-}
-
-/**
- * Shows a notification for each pull request that we haven't yet notified about.
- */
-async function showNotificationForNewPullRequests(pullRequests: PullRequest[]) {
-  for (const pullRequest of pullRequests) {
-    if (!store.github.notifiedPullRequestUrls.has(pullRequest.htmlUrl)) {
-      console.log(`Showing ${pullRequest.htmlUrl}`);
-      showNotification(pullRequest);
-    } else {
-      console.log(`Filtering ${pullRequest.htmlUrl}`);
-    }
-  }
-  store.github.setNotifiedPullRequests(pullRequests);
 }

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -2,22 +2,44 @@ import { chromeApi } from "../chrome";
 import { PullRequest } from "../state/storage/last-check";
 
 /**
+ * Shows a notification for each pull request that we haven't yet notified about.
+ */
+export async function showNotificationForNewPullRequests(
+  unreviewedPullRequests: PullRequest[],
+  notifiedPullRequestUrls: Set<string>
+) {
+  if (!unreviewedPullRequests) {
+    // Do nothing.
+    return;
+  }
+  for (const pullRequest of unreviewedPullRequests) {
+    if (!notifiedPullRequestUrls.has(pullRequest.htmlUrl)) {
+      console.log(`Showing ${pullRequest.htmlUrl}`);
+      showNotification(pullRequest);
+    } else {
+      console.log(`Filtering ${pullRequest.htmlUrl}`);
+    }
+  }
+}
+
+/**
  * Shows a notification if the pull request is new.
  */
-export function showNotification(pullRequest: PullRequest) {
+function showNotification(pullRequest: PullRequest) {
   // We set the notification ID to the URL so that we simply cannot have duplicate
   // notifications about the same pull request and we can easily open a browser tab
   // to this pull request just by knowing the notification ID.
   const notificationId = pullRequest.htmlUrl;
 
   // Chrome supports requireInteraction, but it crashes Firefox.
-  const supportsRequireInteraction = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
+  const supportsRequireInteraction =
+    navigator.userAgent.toLowerCase().indexOf("firefox") === -1;
   chromeApi.notifications.create(notificationId, {
     type: "basic",
     iconUrl: "images/GitHub-Mark-120px-plus.png",
     title: "New pull request",
     message: pullRequest.title,
-    ...(supportsRequireInteraction ? {requireInteraction: true} : {})
+    ...(supportsRequireInteraction ? { requireInteraction: true } : {})
   });
 }
 

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -1,14 +1,15 @@
-import { chromeApi } from "../chrome";
+import { chromeApi } from "./chrome";
+import { PullRequest } from "./state/storage/last-check";
 
 /**
  * Updates the unread PR count in the Chrome extension badge, as well as its color.
  */
-export function updateBadge(prCount: number) {
+export function updateBadge(unreviewedPullRequests: PullRequest[]) {
   chromeApi.browserAction.setBadgeText({
-    text: "" + prCount
+    text: "" + unreviewedPullRequests.length
   });
   chromeApi.browserAction.setBadgeBackgroundColor({
-    color: prCount === 0 ? "#4d4" : "#f00"
+    color: unreviewedPullRequests.length === 0 ? "#4d4" : "#f00"
   });
 }
 

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import React, { Component } from "react";
 import { GitHubState } from "../state/github";
+import { PullRequest } from "../state/storage/last-check";
 import { Header } from "./design/Header";
 import { Error } from "./Error";
 import { Loader } from "./Loader";
@@ -30,6 +31,7 @@ export class Popup extends Component<PopupProps> {
             ) : (
               <PullRequestList
                 pullRequests={this.props.github.unreviewedPullRequests}
+                onMute={this.onMute}
               />
             )}
           </>
@@ -40,4 +42,8 @@ export class Popup extends Component<PopupProps> {
       </>
     );
   }
+
+  private onMute = (pullRequest: PullRequest) => {
+    this.props.github.mutePullRequest(pullRequest);
+  };
 }

--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -86,7 +86,7 @@ export class PullRequestItem extends Component<PullRequestItemProps> {
         <Info>
           <Title>
             {this.props.pullRequest.title}
-            <SmallButton onClick={this.mute}>
+            <SmallButton title="Mute until next update" onClick={this.mute}>
               <FontAwesomeIcon icon="bell-slash" />
             </SmallButton>
           </Title>

--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -1,10 +1,13 @@
 import styled from "@emotion/styled";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { observer } from "mobx-react";
 import React, { Component } from "react";
 import { PullRequest } from "../state/storage/last-check";
+import { SmallButton } from "./design/Button";
 
 export interface PullRequestItemProps {
   pullRequest: PullRequest;
+  onMute(pullRequest: PullRequest): void;
 }
 
 const PullRequestBox = styled.a`
@@ -81,7 +84,12 @@ export class PullRequestItem extends Component<PullRequestItemProps> {
         href={this.props.pullRequest.htmlUrl}
       >
         <Info>
-          <Title>{this.props.pullRequest.title}</Title>
+          <Title>
+            {this.props.pullRequest.title}
+            <SmallButton onClick={this.mute}>
+              <FontAwesomeIcon icon="bell-slash" />
+            </SmallButton>
+          </Title>
           <Repo>
             {this.props.pullRequest.repoOwner}/{this.props.pullRequest.repoName}{" "}
             (#
@@ -97,4 +105,9 @@ export class PullRequestItem extends Component<PullRequestItemProps> {
       </PullRequestBox>
     );
   }
+
+  private mute = (e: React.MouseEvent) => {
+    this.props.onMute(this.props.pullRequest);
+    e.preventDefault();
+  };
 }

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -7,6 +7,7 @@ import { PullRequestItem } from "./PullRequestItem";
 
 export interface PullRequestListProps {
   pullRequests: PullRequest[];
+  onMute(pullRequest: PullRequest): void;
 }
 
 @observer
@@ -17,7 +18,11 @@ export class PullRequestList extends Component<PullRequestListProps> {
     ) : (
       <List>
         {this.props.pullRequests.map(pullRequest => (
-          <PullRequestItem key={pullRequest.nodeId} pullRequest={pullRequest} />
+          <PullRequestItem
+            key={pullRequest.nodeId}
+            pullRequest={pullRequest}
+            onMute={this.props.onMute}
+          />
         ))}
       </List>
     );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
 import { observer } from "mobx-react";
 import React, { Component, FormEvent, RefObject } from "react";
-import { chromeApi } from "../chrome";
 import { GitHubState } from "../state/github";
-import { Button } from "./design/Button";
+import { LargeButton } from "./design/Button";
 import { Center } from "./design/Center";
 import { Header } from "./design/Header";
 import { Link } from "./design/Link";
@@ -69,14 +68,14 @@ export class Settings extends Component<SettingsProps> {
               Signed in as <UserLogin>{this.props.github.user.login}</UserLogin>
               .
             </span>
-            <Button onClick={this.openForm}>Update token</Button>
+            <LargeButton onClick={this.openForm}>Update token</LargeButton>
           </Row>
         </Paragraph>
       ) : this.props.github.status === "failed" ? (
         <Paragraph>
           <Row>
             It looks like your token is invalid.
-            <Button onClick={this.openForm}>Update token</Button>
+            <LargeButton onClick={this.openForm}>Update token</LargeButton>
           </Row>
         </Paragraph>
       ) : (
@@ -87,7 +86,7 @@ export class Settings extends Component<SettingsProps> {
             pull requests.
           </Paragraph>
           <Center>
-            <Button onClick={this.openForm}>Update token</Button>
+            <LargeButton onClick={this.openForm}>Update token</LargeButton>
           </Center>
         </>
       );
@@ -113,8 +112,8 @@ export class Settings extends Component<SettingsProps> {
           </Paragraph>
           <Row>
             <TokenInput ref={this.inputRef} />
-            <Button type="submit">Save</Button>
-            <Button onClick={this.cancelForm}>Cancel</Button>
+            <LargeButton type="submit">Save</LargeButton>
+            <LargeButton onClick={this.cancelForm}>Cancel</LargeButton>
           </Row>
         </form>
       );
@@ -138,9 +137,6 @@ export class Settings extends Component<SettingsProps> {
       .then(() => console.log("GitHub API token updated."));
     this.setState({
       editing: false
-    });
-    chromeApi.runtime.sendMessage({
-      kind: "refresh"
     });
   };
 

--- a/src/components/design/Button.tsx
+++ b/src/components/design/Button.tsx
@@ -1,10 +1,10 @@
 import styled from "@emotion/styled";
 
-export const Button = styled.button`
+const Button = styled.button`
   color: #000;
   background-color: #fff;
   border: none;
-  padding: 4px 16px;
+  padding: 4px;
   margin: 0 4px;
   border-radius: 8px;
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.1);
@@ -17,4 +17,10 @@ export const Button = styled.button`
     box-shadow: 0px 5px 10px rgba(46, 229, 157, 0.4);
     color: #fff;
   }
+`;
+
+export const SmallButton = Button;
+
+export const LargeButton = styled(Button)`
+  padding: 4px 16px;
 `;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,8 +1,12 @@
 import { css, Global } from "@emotion/core";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faBellSlash } from "@fortawesome/free-solid-svg-icons";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Popup } from "./components/Popup";
 import { store } from "./state/store";
+
+library.add(faBellSlash);
 
 ReactDOM.render(
   <>

--- a/src/state/filtering/review-needed.ts
+++ b/src/state/filtering/review-needed.ts
@@ -1,4 +1,5 @@
 import { PullRequest, Review } from "../storage/last-check";
+import { MuteConfiguration } from "../storage/mute";
 
 /**
  * Returns whether another review is needed for a PR:
@@ -7,10 +8,12 @@ import { PullRequest, Review } from "../storage/last-check";
  */
 export function isReviewNeeded(
   pr: PullRequest,
-  currentUserLogin: string
+  currentUserLogin: string,
+  muteConfiguration: MuteConfiguration
 ): boolean {
   return (
     pr.authorLogin !== currentUserLogin &&
+    !isMuted(pr, muteConfiguration) &&
     (reviewRequested(pr, currentUserLogin) ||
       (userDidReview(pr, currentUserLogin) &&
         isNewReviewNeeded(pr.authorLogin, currentUserLogin, pr.reviews)))
@@ -39,8 +42,36 @@ function isNewReviewNeeded(
   currentUserLogin: string,
   reviews: Review[]
 ): boolean {
-  let lastReviewFromCurrentUser = 0;
-  let lastChangeFromAuthor = 0;
+  let lastReviewFromCurrentUser = getLastChangeFrom(currentUserLogin, reviews);
+  let lastChangeFromAuthor = getLastChangeFrom(pullRequestAuthorLogin, reviews);
+  return lastReviewFromCurrentUser < lastChangeFromAuthor;
+}
+
+/**
+ * Returns whether the pull request is muted.
+ */
+function isMuted(pr: PullRequest, muteConfiguration: MuteConfiguration) {
+  for (const muted of muteConfiguration.mutedPullRequests) {
+    if (
+      muted.repo.owner === pr.repoOwner &&
+      muted.repo.name === pr.repoName &&
+      muted.number === pr.pullRequestNumber
+    ) {
+      // It's a match.
+      switch (muted.until.kind) {
+        case "next-update":
+          const updatedSince =
+            getLastChangeFrom(pr.authorLogin, pr.reviews) >
+            muted.until.mutedAtTimestamp;
+          return !updatedSince;
+      }
+    }
+  }
+  return false;
+}
+
+function getLastChangeFrom(login: string, reviews: Review[]) {
+  let lastChange = 0;
   for (const review of reviews) {
     if (review.state === "PENDING") {
       // Ignore pending reviews (we don't want a user to think that they've submitted their
@@ -48,13 +79,9 @@ function isNewReviewNeeded(
       continue;
     }
     const submittedAt = new Date(review.submittedAt).getTime();
-    if (review.authorLogin === pullRequestAuthorLogin) {
-      lastChangeFromAuthor = submittedAt;
-    } else if (review.authorLogin === currentUserLogin) {
-      lastReviewFromCurrentUser = submittedAt;
-    } else {
-      // Comment from someone else. Ignore.
+    if (review.authorLogin === login) {
+      lastChange = submittedAt;
     }
   }
-  return lastReviewFromCurrentUser < lastChangeFromAuthor;
+  return lastChange;
 }

--- a/src/state/github.ts
+++ b/src/state/github.ts
@@ -1,5 +1,7 @@
 import Octokit from "@octokit/rest";
 import { computed, observable } from "mobx";
+import { showNotificationForNewPullRequests } from "../background/notifications";
+import { updateBadge } from "../badge";
 import { chromeApi } from "../chrome";
 import { loadRepos } from "../github/api/repos";
 import {
@@ -89,6 +91,13 @@ export class GitHubState {
       ),
       repos
     });
+    const unreviewedPullRequests = this.unreviewedPullRequests || [];
+    await updateBadge(unreviewedPullRequests);
+    await showNotificationForNewPullRequests(
+      unreviewedPullRequests,
+      this.notifiedPullRequestUrls
+    );
+    await this.setNotifiedPullRequests(unreviewedPullRequests);
   }
 
   async mutePullRequest(pullRequest: PullRequest) {
@@ -104,7 +113,8 @@ export class GitHubState {
       }
     });
     await this.setMuteConfiguration(this.muteConfiguration);
-    this.triggerBackgroundRefresh();
+    const unreviewedPullRequests = this.unreviewedPullRequests || [];
+    await updateBadge(unreviewedPullRequests);
   }
 
   @computed

--- a/src/state/github.ts
+++ b/src/state/github.ts
@@ -1,5 +1,6 @@
 import Octokit from "@octokit/rest";
 import { computed, observable } from "mobx";
+import { chromeApi } from "../chrome";
 import { loadRepos } from "../github/api/repos";
 import {
   GetAuthenticatedUserResponse,
@@ -16,6 +17,11 @@ import {
   pullRequestFromResponse,
   repoFromResponse
 } from "./storage/last-check";
+import {
+  MuteConfiguration,
+  muteConfigurationStorage,
+  NOTHING_MUTED
+} from "./storage/mute";
 import { notifiedPullRequestsStorage } from "./storage/notified-pull-requests";
 import { tokenStorage } from "./storage/token";
 
@@ -26,6 +32,7 @@ export class GitHubState {
   @observable token: string | null = null;
   @observable user: GetAuthenticatedUserResponse | null = null;
   @observable lastCheck: LastCheck | null = null;
+  @observable muteConfiguration = NOTHING_MUTED;
   @observable notifiedPullRequestUrls = new Set<string>();
   @observable lastError: string | null = null;
 
@@ -46,10 +53,12 @@ export class GitHubState {
     await this.setError(null);
     await this.setNotifiedPullRequests([]);
     await this.setLastCheck(null);
+    await this.setMuteConfiguration(NOTHING_MUTED);
     await this.load(token);
     if (this.status === "loaded") {
       await this.refreshPullRequests();
     }
+    this.triggerBackgroundRefresh();
   }
 
   async setNotifiedPullRequests(pullRequests: PullRequest[]) {
@@ -82,6 +91,22 @@ export class GitHubState {
     });
   }
 
+  async mutePullRequest(pullRequest: PullRequest) {
+    this.muteConfiguration.mutedPullRequests.push({
+      repo: {
+        owner: pullRequest.repoOwner,
+        name: pullRequest.repoName
+      },
+      number: pullRequest.pullRequestNumber,
+      until: {
+        kind: "next-update",
+        mutedAtTimestamp: Date.now()
+      }
+    });
+    await this.setMuteConfiguration(this.muteConfiguration);
+    this.triggerBackgroundRefresh();
+  }
+
   @computed
   get unreviewedPullRequests(): PullRequest[] | null {
     if (!this.lastCheck || !this.user) {
@@ -89,13 +114,18 @@ export class GitHubState {
     }
     const userLogin = this.user.login;
     return this.lastCheck.openPullRequests.filter(pr =>
-      isReviewNeeded(pr, userLogin)
+      isReviewNeeded(pr, userLogin, this.muteConfiguration)
     );
   }
 
   private async setLastCheck(lastCheck: LastCheck | null) {
     this.lastCheck = lastCheck;
     await lastCheckStorage.save(lastCheck);
+  }
+
+  private async setMuteConfiguration(muteConfiguration: MuteConfiguration) {
+    this.muteConfiguration = muteConfiguration;
+    await muteConfigurationStorage.save(muteConfiguration);
   }
 
   private async load(token: string | null) {
@@ -111,12 +141,14 @@ export class GitHubState {
         this.notifiedPullRequestUrls = new Set(
           await notifiedPullRequestsStorage.load()
         );
+        this.muteConfiguration = await muteConfigurationStorage.load();
       } else {
         this.token = null;
         this.octokit = null;
         this.user = null;
         this.lastCheck = null;
         this.notifiedPullRequestUrls = new Set();
+        this.muteConfiguration = NOTHING_MUTED;
       }
       this.status = "loaded";
     } catch (e) {
@@ -124,5 +156,11 @@ export class GitHubState {
       this.status = "failed";
       this.setError(e.message);
     }
+  }
+
+  private triggerBackgroundRefresh() {
+    chromeApi.runtime.sendMessage({
+      kind: "refresh"
+    });
   }
 }

--- a/src/state/storage/mute.ts
+++ b/src/state/storage/mute.ts
@@ -1,0 +1,37 @@
+import { storageWithDefault } from "./helper";
+
+export const NOTHING_MUTED: MuteConfiguration = {
+  mutedPullRequests: []
+};
+
+export const muteConfigurationStorage = storageWithDefault(
+  "mute",
+  NOTHING_MUTED
+);
+
+export interface MuteConfiguration {
+  mutedPullRequests: MutedPullRequest[];
+}
+
+export interface MutedPullRequest {
+  repo: {
+    owner: string;
+    name: string;
+  };
+  number: number;
+  until: MutedUntil;
+}
+
+// TODO: Add other types of muting (e.g. forever).
+export type MutedUntil = MutedUntilNextUpdate;
+
+export interface MutedUntilNextUpdate {
+  kind: "next-update";
+
+  /**
+   * The timestamp at which the PR was muted.
+   *
+   * Any update by the author after this timestamp will make the PR re-appear.
+   */
+  mutedAtTimestamp: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,6 +752,33 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
+"@fortawesome/fontawesome-common-types@^0.2.17":
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.17.tgz#d8c36e6f6f3b3415fa1f83eaffe4f41bd313715c"
+  integrity sha512-DEYsEb/iiGVoMPQGjhG2uOylLVuMzTxOxysClkabZ5n80Q3oFDWGnshCLKvOvKoeClsgmKhWVrnnqvsMI1cAbw==
+
+"@fortawesome/fontawesome-svg-core@^1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.17.tgz#8fce4402e824ebe99a04b1949d56d696eeae2e6d"
+  integrity sha512-TORMW/wIX2QyyGBd4XwHGPir4/0U18Wxf+iDBAUW3EIJ0/VC/ZMpJOiyiCe1f8g9h0PPzA7sqVtl8JtTUtm4uA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.17"
+
+"@fortawesome/free-solid-svg-icons@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.1.tgz#086c70f95b34a4bcf6f50ff1078d46e53486eb52"
+  integrity sha512-FUcxR75PtMOo3ihRHJOZz64IsWIVdWgB2vCMLJjquTv487wVVCMH5H5gWa72et2oI9lKKD2jvjQ+y+7mxhscVQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.17"
+
+"@fortawesome/react-fontawesome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@octokit/endpoint@^3.2.0":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-3.2.3.tgz#bd9aea60cd94ce336656b57a5c9cb7f10be8f4f3"
@@ -2901,6 +2928,11 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
 iconv-lite@0.4.23:
   version "0.4.23"


### PR DESCRIPTION
This is a massive PR with a fair few changes:
- introducing fontawesome icons, so we have a nice "mute" icon
- splitting up Button into SmallButton + LargeButton
- refactoring badge and notification update so it's triggered from GitHubState consistently
- adding MuteConfiguration and using it to filter out muted PRs