### PR TITLE
Improve computing of "last update time"

### DIFF
--- a/src/github/api/comments.ts
+++ b/src/github/api/comments.ts
@@ -1,0 +1,19 @@
+import Octokit, { PullsListCommentsResponse } from "@octokit/rest";
+
+/**
+ * Loads all comments for a given pull request.
+ */
+export async function loadComments(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullRequestNumber: number
+): Promise<PullsListCommentsResponse> {
+  return octokit.paginate(
+    octokit.pulls.listComments.endpoint.merge({
+      owner,
+      repo,
+      number: pullRequestNumber
+    })
+  );
+}

--- a/src/state/filtering/review-needed.ts
+++ b/src/state/filtering/review-needed.ts
@@ -31,7 +31,10 @@ function reviewRequested(pr: PullRequest, currentUserLogin: string): boolean {
  * Returns whether the user previously reviewed a PR (even if not explicitly requested).
  */
 function userDidReview(pr: PullRequest, currentUserLogin: string): boolean {
-  return pr.reviews.findIndex(r => r.authorLogin === currentUserLogin) !== -1;
+  return (
+    (pr.comments || []).findIndex(r => r.authorLogin === currentUserLogin) !==
+      -1 || pr.reviews.findIndex(r => r.authorLogin === currentUserLogin) !== -1
+  );
 }
 
 /**
@@ -82,7 +85,13 @@ function getLastReviewTimestamp(pr: PullRequest, login: string): number {
     }
     const submittedAt = new Date(review.submittedAt).getTime();
     if (review.authorLogin === login) {
-      lastChange = submittedAt;
+      lastChange = Math.max(lastChange, submittedAt);
+    }
+  }
+  for (const comment of pr.comments || []) {
+    const createdAt = new Date(comment.createdAt).getTime();
+    if (comment.authorLogin === login) {
+      lastChange = Math.max(lastChange, createdAt);
     }
   }
   return lastChange;

--- a/src/state/github.ts
+++ b/src/state/github.ts
@@ -6,6 +6,7 @@ import { chromeApi } from "../chrome";
 import { loadRepos } from "../github/api/repos";
 import { loadAuthenticatedUser } from "../github/api/user";
 import { isReviewNeeded } from "./filtering/review-needed";
+import { loadAllComments } from "./loading/comments";
 import { refreshOpenPullRequests } from "./loading/pull-requests";
 import { loadAllReviews } from "./loading/reviews";
 import { lastErrorStorage } from "./storage/error";
@@ -121,10 +122,18 @@ export class GitHubState {
         octokit,
         openPullRequests
       );
+      const commentsPerPullRequest = await loadAllComments(
+        octokit,
+        openPullRequests
+      );
       await this.setLastCheck({
         userLogin: user.login,
         openPullRequests: openPullRequests.map(pr =>
-          pullRequestFromResponse(pr, reviewsPerPullRequest[pr.node_id])
+          pullRequestFromResponse(
+            pr,
+            reviewsPerPullRequest[pr.node_id],
+            commentsPerPullRequest[pr.node_id]
+          )
         ),
         repos
       });

--- a/src/state/loading/comments.ts
+++ b/src/state/loading/comments.ts
@@ -1,0 +1,41 @@
+import Octokit, {
+  PullsGetResponse,
+  PullsListCommentsResponse,
+  PullsListResponseItem
+} from "@octokit/rest";
+import { loadComments } from "../../github/api/comments";
+
+/**
+ * Loads all comments for a set of pull requests.
+ *
+ * @returns a dictionary where keys are pull request node IDs.
+ */
+export async function loadAllComments(
+  octokit: Octokit,
+  pullRequests: Array<PullsListResponseItem | PullsGetResponse>
+): Promise<{
+  [pullRequestNodeId: string]: PullsListCommentsResponse;
+}> {
+  const comments = await Promise.all(
+    pullRequests.map(
+      async (
+        pr
+      ): Promise<[string /* node ID */, PullsListCommentsResponse]> => [
+        pr.node_id,
+        await loadComments(
+          octokit,
+          pr.base.repo.owner.login,
+          pr.base.repo.name,
+          pr.number
+        )
+      ]
+    )
+  );
+  const commentsPerPullRequest = comments.reduce<{
+    [pullRequestNodeId: string]: PullsListCommentsResponse;
+  }>((acc, [nodeId, comments]) => {
+    acc[nodeId] = comments;
+    return acc;
+  }, {});
+  return commentsPerPullRequest;
+}

--- a/src/state/storage/last-check.ts
+++ b/src/state/storage/last-check.ts
@@ -1,5 +1,6 @@
 import {
   PullsGetResponse,
+  PullsListCommentsResponse,
   PullsListResponseItem,
   ReposGetResponse
 } from "@octokit/rest";
@@ -62,14 +63,23 @@ export interface PullRequest {
   pullRequestNumber: number;
   // TODO: Remove in May 2019 (deprecated in favour of author object).
   authorLogin: string;
+  // TODO: Make required in May 2019.
   author?: {
     login: string;
     avatarUrl: string;
   };
+  // TODO: Make required in May 2019.
   updatedAt?: string;
   title: string;
   requestedReviewers: string[];
   reviews: Review[];
+  // TODO: Make required in May 2019.
+  comments?: Comment[];
+}
+
+export interface Comment {
+  authorLogin: string;
+  createdAt: string;
 }
 
 export interface Review {
@@ -80,7 +90,8 @@ export interface Review {
 
 export function pullRequestFromResponse(
   response: PullsGetResponse | PullsListResponseItem,
-  reviews: PullsListReviewsResponse
+  reviews: PullsListReviewsResponse,
+  comments: PullsListCommentsResponse
 ): PullRequest {
   return {
     nodeId: response.node_id,
@@ -100,6 +111,10 @@ export function pullRequestFromResponse(
       authorLogin: r.user.login,
       state: r.state,
       submittedAt: r.submitted_at
+    })),
+    comments: comments.map(c => ({
+      authorLogin: c.user.login,
+      createdAt: c.created_at
     }))
   };
 }

--- a/src/state/storage/last-check.ts
+++ b/src/state/storage/last-check.ts
@@ -66,6 +66,7 @@ export interface PullRequest {
     login: string;
     avatarUrl: string;
   };
+  updatedAt?: string;
   title: string;
   requestedReviewers: string[];
   reviews: Review[];
@@ -92,6 +93,7 @@ export function pullRequestFromResponse(
       login: response.user.login,
       avatarUrl: response.user.avatar_url
     },
+    updatedAt: response.updated_at,
     title: response.title,
     requestedReviewers: response.requested_reviewers.map(r => r.login),
     reviews: reviews.map(r => ({


### PR DESCRIPTION
This should fix a bug with PR muting where pushing new commits wouldn't refresh.

Two core changes:
- we now look at the PR's last updated time overall (which should be reflective of new commits)
- we also look at comments (not just reviews)