### PR TITLE
Rename GitHubState -> Core and LastCheck -> LoadedState

### DIFF
--- a/src/background/check-pull-requests.ts
+++ b/src/background/check-pull-requests.ts
@@ -1,5 +1,5 @@
 import { ChromeApi } from "../chrome";
-import { GitHubState } from "../state/github";
+import { Core } from "../state/core";
 import { GitHubLoader } from "../state/github-loader";
 import { getStore } from "../state/storage/store";
 
@@ -11,16 +11,16 @@ export async function checkPullRequests(
   githubLoader: GitHubLoader
 ) {
   let error;
-  const github = new GitHubState(chromeApi, getStore(chromeApi), githubLoader);
+  const core = new Core(chromeApi, getStore(chromeApi), githubLoader);
   try {
-    await github.load();
-    if (!github.token) {
+    await core.load();
+    if (!core.token) {
       return;
     }
-    await github.refreshPullRequests();
+    await core.refreshPullRequests();
     error = null;
   } catch (e) {
     error = e;
   }
-  github.setError(error ? error.message : null);
+  core.setError(error ? error.message : null);
 }

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import React, { Component } from "react";
-import { GitHubState } from "../state/github";
+import { Core } from "../state/core";
 import { PullRequest } from "../state/storage/last-check";
 import { Header } from "./design/Header";
 import { Error } from "./Error";
@@ -9,35 +9,35 @@ import { PullRequestList } from "./PullRequestList";
 import { Settings } from "./Settings";
 
 export interface PopupProps {
-  github: GitHubState;
+  core: Core;
 }
 
 @observer
 export class Popup extends Component<PopupProps> {
   async componentDidMount() {
-    await this.props.github.load();
-    await this.props.github.refreshPullRequests();
+    await this.props.core.load();
+    await this.props.core.refreshPullRequests();
   }
 
   render() {
     return (
       <>
-        <Error lastError={this.props.github.lastError} />
-        {this.props.github.token && !this.props.github.lastError && (
+        <Error lastError={this.props.core.lastError} />
+        {this.props.core.token && !this.props.core.lastError && (
           <>
             <Header>Pull requests</Header>
-            {this.props.github.unreviewedPullRequests === null ? (
+            {this.props.core.unreviewedPullRequests === null ? (
               <Loader />
             ) : (
               <PullRequestList
-                pullRequests={this.props.github.unreviewedPullRequests}
+                pullRequests={this.props.core.unreviewedPullRequests}
                 onMute={this.onMute}
               />
             )}
           </>
         )}
-        {this.props.github.overallStatus !== "loading" && (
-          <Settings github={this.props.github} />
+        {this.props.core.overallStatus !== "loading" && (
+          <Settings core={this.props.core} />
         )}
       </>
     );
@@ -51,7 +51,7 @@ export class Popup extends Component<PopupProps> {
         }\n\nThe pull request will re-appear when the author updates it.`
       )
     ) {
-      this.props.github.mutePullRequest(pullRequest);
+      this.props.core.mutePullRequest(pullRequest);
     }
   };
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -61,13 +61,13 @@ export class Settings extends Component<SettingsProps> {
         ? !this.props.core.token
         : this.state.editing;
     if (!editing) {
-      return this.props.core.lastCheck ? (
+      return this.props.core.loadedState ? (
         <Paragraph>
           <Row>
             <span>
               Signed in as{" "}
               <UserLogin>
-                {this.props.core.lastCheck.userLogin || "unknown"}
+                {this.props.core.loadedState.userLogin || "unknown"}
               </UserLogin>
               .
             </span>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { observer } from "mobx-react";
 import React, { Component, FormEvent, RefObject } from "react";
-import { GitHubState } from "../state/github";
+import { Core } from "../state/core";
 import { LargeButton } from "./design/Button";
 import { Center } from "./design/Center";
 import { Header } from "./design/Header";
@@ -10,7 +10,7 @@ import { Paragraph } from "./design/Paragraph";
 import { Row } from "./design/Row";
 
 export interface SettingsProps {
-  github: GitHubState;
+  core: Core;
 }
 
 const UserLogin = styled.span`
@@ -58,30 +58,30 @@ export class Settings extends Component<SettingsProps> {
     // - editing is explicitly set to true (user opened the form).
     const editing =
       this.state.editing === "default"
-        ? !this.props.github.token
+        ? !this.props.core.token
         : this.state.editing;
     if (!editing) {
-      return this.props.github.lastCheck ? (
+      return this.props.core.lastCheck ? (
         <Paragraph>
           <Row>
             <span>
               Signed in as{" "}
               <UserLogin>
-                {this.props.github.lastCheck.userLogin || "unknown"}
+                {this.props.core.lastCheck.userLogin || "unknown"}
               </UserLogin>
               .
             </span>
             <LargeButton onClick={this.openForm}>Update token</LargeButton>
           </Row>
         </Paragraph>
-      ) : this.props.github.lastError ? (
+      ) : this.props.core.lastError ? (
         <Paragraph>
           <Row>
             Is your token valid?
             <LargeButton onClick={this.openForm}>Update token</LargeButton>
           </Row>
         </Paragraph>
-      ) : this.props.github.token ? (
+      ) : this.props.core.token ? (
         <Paragraph>
           <Row>
             We're loading your pull requests. This could take a while...
@@ -103,7 +103,7 @@ export class Settings extends Component<SettingsProps> {
     } else {
       return (
         <form onSubmit={this.saveForm}>
-          {!this.props.github.token && (
+          {!this.props.core.token && (
             <Paragraph>
               Welcome to PR Monitor! In order to use this Chrome extension, you
               need to provide a GitHub API token. This will be used to load your
@@ -142,7 +142,7 @@ export class Settings extends Component<SettingsProps> {
       return;
     }
     const token = this.inputRef.current.value;
-    this.props.github
+    this.props.core
       .setNewToken(token)
       .then(() => console.log("GitHub API token updated."));
     this.setState({

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { chromeApiSingleton } from "./chrome";
 import { Popup } from "./components/Popup";
-import { GitHubState } from "./state/github";
+import { Core } from "./state/core";
 import { githubLoaderSingleton } from "./state/github-loader";
 import { getStore } from "./state/storage/store";
 
@@ -34,8 +34,8 @@ ReactDOM.render(
       `}
     />
     <Popup
-      github={
-        new GitHubState(
+      core={
+        new Core(
           chromeApiSingleton,
           getStore(chromeApiSingleton),
           githubLoaderSingleton

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -1,7 +1,7 @@
 import { ChromeApi, ChromeStorageItems } from "../chrome";
 import { Core } from "./core";
 import { Storage } from "./storage/helper";
-import { LastCheck } from "./storage/last-check";
+import { LoadedState } from "./storage/last-check";
 import { MuteConfiguration } from "./storage/mute";
 import { Store } from "./storage/store";
 
@@ -18,7 +18,7 @@ describe("Core", () => {
 function mockStore(): Store {
   return {
     lastError: mockStorage<string | null>(),
-    lastCheck: mockStorage<LastCheck | null>(),
+    lastCheck: mockStorage<LoadedState | null>(),
     muteConfiguration: mockStorage<MuteConfiguration>(),
     notifiedPullRequests: mockStorage<string[]>(),
     token: mockStorage<string | null>()

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -1,17 +1,17 @@
 import { ChromeApi, ChromeStorageItems } from "../chrome";
-import { GitHubState } from "./github";
+import { Core } from "./core";
 import { Storage } from "./storage/helper";
 import { LastCheck } from "./storage/last-check";
 import { MuteConfiguration } from "./storage/mute";
 import { Store } from "./storage/store";
 
-describe("GitHubState", () => {
+describe("Core", () => {
   it("does something", async () => {
     const chrome = fakeChrome();
     const store = mockStore();
     const githubLoader = jest.fn();
-    const github = new GitHubState(chrome.chromeApi, store, githubLoader);
-    await github.load();
+    const core = new Core(chrome.chromeApi, store, githubLoader);
+    await core.load();
   });
 });
 

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -9,7 +9,7 @@ import { LastCheck, PullRequest } from "./storage/last-check";
 import { MuteConfiguration, NOTHING_MUTED } from "./storage/mute";
 import { Store } from "./storage/store";
 
-export class GitHubState {
+export class Core {
   private readonly chromeApi: ChromeApi;
   private readonly store: Store;
   private readonly githubLoader: GitHubLoader;

--- a/src/state/github-loader.ts
+++ b/src/state/github-loader.ts
@@ -5,7 +5,7 @@ import { loadAllComments } from "./loading/comments";
 import { refreshOpenPullRequests } from "./loading/pull-requests";
 import { loadAllReviews } from "./loading/reviews";
 import {
-  LastCheck,
+  LoadedState,
   pullRequestFromResponse,
   repoFromResponse
 } from "./storage/last-check";
@@ -15,8 +15,8 @@ import {
  */
 export const githubLoaderSingleton: GitHubLoader = async function load(
   octokit: Octokit,
-  lastCheck: LastCheck | null
-): Promise<LastCheck> {
+  lastCheck: LoadedState | null
+): Promise<LoadedState> {
   const user = await loadAuthenticatedUser(octokit);
   const repos = await loadRepos(octokit).then(r => r.map(repoFromResponse));
   const openPullRequests = await refreshOpenPullRequests(
@@ -44,5 +44,5 @@ export const githubLoaderSingleton: GitHubLoader = async function load(
 
 export type GitHubLoader = (
   octokit: Octokit,
-  lastCheck: LastCheck | null
-) => Promise<LastCheck>;
+  lastCheck: LoadedState | null
+) => Promise<LoadedState>;

--- a/src/state/loading/pull-requests.ts
+++ b/src/state/loading/pull-requests.ts
@@ -7,7 +7,7 @@ import {
   loadPullRequests
 } from "../../github/api/pull-requests";
 import { repoWasPushedAfter } from "../filtering/repos-pushed-after";
-import { LastCheck, Repo } from "../storage/last-check";
+import { LoadedState, Repo } from "../storage/last-check";
 
 /**
  * Refreshes the list of pull requests for a list of repositories.
@@ -19,7 +19,7 @@ import { LastCheck, Repo } from "../storage/last-check";
 export async function refreshOpenPullRequests(
   octokit: Octokit,
   freshlyLoadedRepos: Repo[],
-  lastCheck: LastCheck | null
+  lastCheck: LoadedState | null
 ): Promise<Array<PullsListResponseItem | PullsGetResponse>> {
   const maximumPushedAt =
     lastCheck && lastCheck.repos.length > 0

--- a/src/state/storage/last-check.ts
+++ b/src/state/storage/last-check.ts
@@ -15,9 +15,9 @@ import { storage } from "./helper";
  * Storage of the last information we loaded about pull requests.
  */
 export const lastCheckStorage = (chromeApi: ChromeApi) =>
-  storage<LastCheck>(chromeApi, "lastCheck");
+  storage<LoadedState>(chromeApi, "lastCheck");
 
-export interface LastCheck {
+export interface LoadedState {
   // TODO: Make it required once the field has been populated for long enough.
   userLogin?: string;
 

--- a/src/state/storage/store.ts
+++ b/src/state/storage/store.ts
@@ -1,7 +1,7 @@
 import { ChromeApi } from "../../chrome";
 import { lastErrorStorage } from "./error";
 import { Storage } from "./helper";
-import { LastCheck, lastCheckStorage } from "./last-check";
+import { lastCheckStorage, LoadedState } from "./last-check";
 import { MuteConfiguration, muteConfigurationStorage } from "./mute";
 import { notifiedPullRequestsStorage } from "./notified-pull-requests";
 import { tokenStorage } from "./token";
@@ -18,7 +18,7 @@ export function getStore(chromeApi: ChromeApi): Store {
 
 export interface Store {
   lastError: Storage<string | null>;
-  lastCheck: Storage<LastCheck | null>;
+  lastCheck: Storage<LoadedState | null>;
   muteConfiguration: Storage<MuteConfiguration>;
   notifiedPullRequests: Storage<string[]>;
   token: Storage<string | null>;


### PR DESCRIPTION
This should better represent what these types are. In particular, GitHubState no longer had anything specific to GitHub (apart from delegating to GitHubLoader). This means that we could later extend it to support other hosting services.