### PR TITLE
Reduce spurious notifications about PRs

### DIFF
--- a/src/state/filtering/review-needed.spec.ts
+++ b/src/state/filtering/review-needed.spec.ts
@@ -11,8 +11,7 @@ const DUMMY_PR: PullRequest = {
   htmlUrl: "https://github.com/zenclabs/prmonitor/pull/1",
   nodeId: "fake",
   requestedReviewers: [],
-  reviews: [],
-  updatedAt: "2019-03-15T17:00:11Z"
+  reviews: []
 };
 
 const NO_MUTING: MuteConfiguration = {
@@ -59,7 +58,7 @@ describe("isReviewNeeded", () => {
       )
     ).toBe(true);
   });
-  it("is true when the user is not a reviewer but had reviewed, and new changes are made", () => {
+  it("is true when the user is not a reviewer but had reviewed, and the author responds", () => {
     expect(
       isReviewNeeded(
         {
@@ -73,14 +72,19 @@ describe("isReviewNeeded", () => {
               submittedAt: "2019-02-15T17:00:11Z"
             }
           ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          comments: [
+            {
+              authorLogin: "fwouts",
+              createdAt: "2019-02-16T17:00:11Z"
+            }
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is true when the user is not a reviewer but had commented, and new changes are made", () => {
+  it("is true when the user is not a reviewer but had commented, and the author responds", () => {
     expect(
       isReviewNeeded(
         {
@@ -91,16 +95,19 @@ describe("isReviewNeeded", () => {
             {
               authorLogin: "kevin",
               createdAt: "2019-02-15T17:00:11Z"
+            },
+            {
+              authorLogin: "fwouts",
+              createdAt: "2019-02-16T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is false when the user has reviewed after the last changes", () => {
+  it("is false when the user has reviewed and the author hasn't responded", () => {
     expect(
       isReviewNeeded(
         {
@@ -113,15 +120,14 @@ describe("isReviewNeeded", () => {
               state: "COMMENTED",
               submittedAt: "2019-04-15T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(false);
   });
-  it("is false when the user has commented after the last changes", () => {
+  it("is false when the user has commented and the author hasn't responded", () => {
     expect(
       isReviewNeeded(
         {
@@ -134,14 +140,21 @@ describe("isReviewNeeded", () => {
               createdAt: "2019-04-15T17:00:11Z"
             }
           ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          // Another user posted a review after we muted.
+          reviews: [
+            {
+              authorLogin: "dries",
+              state: "CHANGES_REQUESTED",
+              submittedAt: "2019-03-18T17:00:11Z"
+            }
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(false);
   });
-  it("is true when the PR was not updated but a review was explicitly requested from the user", () => {
+  it("is true when the author did not respond but a review was explicitly requested from the user", () => {
     expect(
       isReviewNeeded(
         {
@@ -153,15 +166,14 @@ describe("isReviewNeeded", () => {
               authorLogin: "kevin",
               createdAt: "2019-04-15T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is true when the author wrote a new comment without updating the PR", () => {
+  it("is true when the author responded with a comment", () => {
     expect(
       isReviewNeeded(
         {
@@ -177,15 +189,14 @@ describe("isReviewNeeded", () => {
               authorLogin: "fwouts",
               createdAt: "2019-04-16T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is true when the author wrote a new review without updating the PR", () => {
+  it("is true when the author responded with a review", () => {
     expect(
       isReviewNeeded(
         {
@@ -204,15 +215,14 @@ describe("isReviewNeeded", () => {
               state: "COMMENTED",
               submittedAt: "2019-04-16T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is true when the PR was reviewed but has been updated", () => {
+  it("is true when the PR was reviewed but the author responded", () => {
     expect(
       isReviewNeeded(
         {
@@ -226,14 +236,19 @@ describe("isReviewNeeded", () => {
               submittedAt: "2019-02-15T17:00:11Z"
             }
           ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          comments: [
+            {
+              authorLogin: "fwouts",
+              createdAt: "2019-02-16T17:00:11Z"
+            }
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("is true when the PR was approved and has been updated", () => {
+  it("is true when the PR was approved but the author responded", () => {
     expect(
       isReviewNeeded(
         {
@@ -247,7 +262,12 @@ describe("isReviewNeeded", () => {
               submittedAt: "2019-02-15T17:00:11Z"
             }
           ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          comments: [
+            {
+              authorLogin: "fwouts",
+              createdAt: "2019-02-16T17:00:11Z"
+            }
+          ]
         },
         "kevin",
         NO_MUTING
@@ -260,29 +280,27 @@ describe("isReviewNeeded", () => {
         {
           ...DUMMY_PR,
           authorLogin: "fwouts",
-          requestedReviewers: [],
+          requestedReviewers: ["kevin"],
           reviews: [
             {
               authorLogin: "kevin",
               state: "PENDING",
               submittedAt: "2019-04-15T17:00:11Z"
             }
-          ],
-          updatedAt: "2019-03-15T17:00:11Z"
+          ]
         },
         "kevin",
         NO_MUTING
       )
     ).toBe(true);
   });
-  it("ignores muted PRs that have not been updated since muting", () => {
+  it("ignores muted PRs that the author did not add new comments or reviews to", () => {
     expect(
       isReviewNeeded(
         {
           ...DUMMY_PR,
           authorLogin: "fwouts",
           requestedReviewers: ["kevin"],
-          updatedAt: "2019-03-15T17:00:11Z",
           reviews: [
             // Another user posted a review after we muted.
             {
@@ -311,42 +329,13 @@ describe("isReviewNeeded", () => {
       )
     ).toBe(false);
   });
-  it("does not mute PRs that have been updated since muting", () => {
+  it("does not mute PRs that the author added comments to since muting", () => {
     expect(
       isReviewNeeded(
         {
           ...DUMMY_PR,
           authorLogin: "fwouts",
           requestedReviewers: ["kevin"],
-          updatedAt: "2019-03-20T17:00:11Z"
-        },
-        "kevin",
-        {
-          mutedPullRequests: [
-            {
-              repo: {
-                owner: "zenclabs",
-                name: "prmonitor"
-              },
-              number: 1,
-              until: {
-                kind: "next-update",
-                mutedAtTimestamp: new Date("2019-03-16T17:00:11Z").getTime()
-              }
-            }
-          ]
-        }
-      )
-    ).toBe(true);
-  });
-  it("does not mute PRs that have been commented on by author since muting", () => {
-    expect(
-      isReviewNeeded(
-        {
-          ...DUMMY_PR,
-          authorLogin: "fwouts",
-          requestedReviewers: ["kevin"],
-          updatedAt: "2019-03-15T17:00:11Z",
           comments: [
             {
               authorLogin: "fwouts",

--- a/src/state/filtering/review-needed.spec.ts
+++ b/src/state/filtering/review-needed.spec.ts
@@ -127,13 +127,13 @@ describe("isReviewNeeded", () => {
       )
     ).toBe(false);
   });
-  it("is false when the user has commented and the author hasn't responded", () => {
+  it("is false when the user is a reviewer, has commented and the author hasn't responded", () => {
     expect(
       isReviewNeeded(
         {
           ...DUMMY_PR,
           authorLogin: "fwouts",
-          requestedReviewers: [],
+          requestedReviewers: ["kevin"],
           comments: [
             {
               authorLogin: "kevin",
@@ -153,25 +153,6 @@ describe("isReviewNeeded", () => {
         NO_MUTING
       )
     ).toBe(false);
-  });
-  it("is true when the author did not respond but a review was explicitly requested from the user", () => {
-    expect(
-      isReviewNeeded(
-        {
-          ...DUMMY_PR,
-          authorLogin: "fwouts",
-          requestedReviewers: ["kevin"],
-          comments: [
-            {
-              authorLogin: "kevin",
-              createdAt: "2019-04-15T17:00:11Z"
-            }
-          ]
-        },
-        "kevin",
-        NO_MUTING
-      )
-    ).toBe(true);
   });
   it("is true when the author responded with a comment", () => {
     expect(

--- a/src/state/filtering/review-needed.ts
+++ b/src/state/filtering/review-needed.ts
@@ -46,9 +46,6 @@ function isNewReviewNeeded(pr: PullRequest, currentUserLogin: string): boolean {
     currentUserLogin
   );
   const lastCommentFromAuthor = getLastAuthorCommentTimestamp(pr);
-  if (pr.repoName === "test-repo-for-prmonitor") {
-    console.log(lastReviewOrCommentFromCurrentUser, lastCommentFromAuthor);
-  }
   return (
     lastReviewOrCommentFromCurrentUser === 0 ||
     lastReviewOrCommentFromCurrentUser < lastCommentFromAuthor

--- a/src/state/filtering/review-needed.ts
+++ b/src/state/filtering/review-needed.ts
@@ -41,9 +41,12 @@ function userDidReview(pr: PullRequest, currentUserLogin: string): boolean {
  * Returns whether the user, who previously wrote a review, needs to take another look.
  */
 function isNewReviewNeeded(pr: PullRequest, currentUserLogin: string): boolean {
-  let lastReviewFromCurrentUser = getLastReviewTimestamp(pr, currentUserLogin);
-  let lastChangeFromAuthor = getLastAuthorUpdateTimestamp(pr);
-  return lastReviewFromCurrentUser < lastChangeFromAuthor;
+  const lastReviewFromCurrentUser = getLastReviewTimestamp(
+    pr,
+    currentUserLogin
+  );
+  const lastCommentFromAuthor = getLastAuthorCommentTimestamp(pr);
+  return lastReviewFromCurrentUser < lastCommentFromAuthor;
 }
 
 /**
@@ -60,7 +63,7 @@ function isMuted(pr: PullRequest, muteConfiguration: MuteConfiguration) {
       switch (muted.until.kind) {
         case "next-update":
           const updatedSince =
-            getLastAuthorUpdateTimestamp(pr) > muted.until.mutedAtTimestamp;
+            getLastAuthorCommentTimestamp(pr) > muted.until.mutedAtTimestamp;
           return !updatedSince;
       }
     }
@@ -68,15 +71,12 @@ function isMuted(pr: PullRequest, muteConfiguration: MuteConfiguration) {
   return false;
 }
 
-function getLastAuthorUpdateTimestamp(pr: PullRequest): number {
-  return Math.max(
-    getLastReviewTimestamp(pr, pr.authorLogin),
-    pr.updatedAt ? new Date(pr.updatedAt).getTime() : 0
-  );
+function getLastAuthorCommentTimestamp(pr: PullRequest): number {
+  return getLastReviewTimestamp(pr, pr.authorLogin);
 }
 
 function getLastReviewTimestamp(pr: PullRequest, login: string): number {
-  let lastChange = 0;
+  let lastCommentedTime = 0;
   for (const review of pr.reviews) {
     if (review.state === "PENDING") {
       // Ignore pending reviews (we don't want a user to think that they've submitted their
@@ -85,14 +85,14 @@ function getLastReviewTimestamp(pr: PullRequest, login: string): number {
     }
     const submittedAt = new Date(review.submittedAt).getTime();
     if (review.authorLogin === login) {
-      lastChange = Math.max(lastChange, submittedAt);
+      lastCommentedTime = Math.max(lastCommentedTime, submittedAt);
     }
   }
   for (const comment of pr.comments || []) {
     const createdAt = new Date(comment.createdAt).getTime();
     if (comment.authorLogin === login) {
-      lastChange = Math.max(lastChange, createdAt);
+      lastCommentedTime = Math.max(lastCommentedTime, createdAt);
     }
   }
-  return lastChange;
+  return lastCommentedTime;
 }

--- a/src/state/github-loader.ts
+++ b/src/state/github-loader.ts
@@ -73,7 +73,6 @@ function pullRequestFromResponse(
       login: response.user.login,
       avatarUrl: response.user.avatar_url
     },
-    updatedAt: response.updated_at,
     title: response.title,
     requestedReviewers: response.requested_reviewers.map(r => r.login),
     reviews: reviews.map(r => ({

--- a/src/storage/loaded-state.ts
+++ b/src/storage/loaded-state.ts
@@ -44,8 +44,6 @@ export interface PullRequest {
     login: string;
     avatarUrl: string;
   };
-  // TODO: Make required in May 2019.
-  updatedAt?: string;
   title: string;
   requestedReviewers: string[];
   reviews: Review[];


### PR DESCRIPTION
This solves two separate issues.

1) Fix a bug where any comment on a PR would make it re-appear

We were relying on pr.updated_at, which actually gets updated any time there is any activity on the PR, including someone else commenting on it. It turns out pr.head.repo.pushed_at is also updated even when a different branch (master) is pushed, so we can't rely on that either.

This changes the approach to only notifying you when the author replies with at least one comment.

Further improvements could be made, for example looking at whether the author responded to you, or to another reviewer. For now, this should already decrease false positives significantly.

2) Fix another bug where adding a comment was not considered to be a valid review

It turns out when a review is requested from you and you just reply with a comment, GitHub leaves you in the "requested reviewers" list.

It seems more reasonable to temporarily hide the PR, until the author responds.