### PR TITLE
Use TypeScript compiler for watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server --open",
-    "watch:dev": "rm -rf dist; webpack --mode development --watch",
-    "watch:prod": "rm -rf dist; webpack --mode production --watch",
+    "watch": "tsc --noEmit --watch",
     "build": "rm -rf dist; webpack --mode production && cd dist && zip extension.zip -r *",
     "test": "jest",
     "prettier:fix": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\""


### PR DESCRIPTION
There were two issues:
- watch:dev was slow and emitted code that couldn't actually run as a Chrome extension (security issue because of eval)
- watch:prod was too slow to give prompt feedback

It seems more reasonable to:
- use the TypeScript compiler (new watch command) to get almost instant feedback about compilation errors
- when necessary, use the existing build command to generate a new extension