### PR TITLE
Abstract away Navigator API

### DIFF
--- a/src/environment/api.ts
+++ b/src/environment/api.ts
@@ -10,4 +10,5 @@ export interface Environment {
   notifier: Notifier;
   badger: Badger;
   messenger: CrossScriptMessenger;
+  isOnline(): boolean;
 }

--- a/src/environment/implementation.ts
+++ b/src/environment/implementation.ts
@@ -12,6 +12,7 @@ export function buildEnvironment(chromeApi: ChromeApi): Environment {
     githubLoader: buildGitHubLoader(),
     notifier: buildNotifier(chromeApi),
     badger: buildBadger(chromeApi),
-    messenger: buildMessenger(chromeApi)
+    messenger: buildMessenger(chromeApi),
+    isOnline: () => navigator.onLine
   };
 }

--- a/src/environment/testing/fake.ts
+++ b/src/environment/testing/fake.ts
@@ -13,12 +13,15 @@ export function buildTestingEnvironment() {
   const notifier = fakeNotifier();
   const badger = fakeBadger();
   const messenger = fakeMessenger();
+  let online = false;
   return {
     store,
     githubLoader,
     notifier,
     badger,
-    messenger
+    messenger,
+    isOnline: () => online,
+    online
   };
 }
 

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -62,7 +62,7 @@ export class Core {
       console.debug("Not authenticated, skipping refresh.");
       return;
     }
-    if (!navigator.onLine) {
+    if (!this.env.isOnline()) {
       console.debug("Not online, skipping refresh.");
       return;
     }


### PR DESCRIPTION
This wouldn't work in Jest otherwise, and it's much easier to mock this way.