### PR TITLE
Add proper test coverage for Core

### DIFF
--- a/src/environment/testing/fake.ts
+++ b/src/environment/testing/fake.ts
@@ -9,7 +9,10 @@ import {
 
 export function buildTestingEnvironment() {
   const store = mockStore();
-  const githubLoader = jest.fn();
+  const githubLoader = jest.fn<
+    Promise<LoadedState>,
+    [string, LoadedState | null]
+  >();
   const notifier = fakeNotifier();
   const badger = fakeBadger();
   const messenger = fakeMessenger();
@@ -34,8 +37,10 @@ function mockStore() {
 
 function mockStorage<T>(defaultValue: T) {
   return {
-    load: jest.fn().mockReturnValue(defaultValue),
-    save: jest.fn()
+    load: jest
+      .fn<Promise<T>, []>()
+      .mockReturnValue(Promise.resolve(defaultValue)),
+    save: jest.fn<Promise<void>, []>()
   };
 }
 
@@ -51,7 +56,7 @@ function fakeNotifier() {
         notifiedPullRequestUrls
       });
     },
-    registerClickListener: jest.fn()
+    registerClickListener: jest.fn<void, []>()
   };
   return {
     ...notifier,

--- a/src/environment/testing/fake.ts
+++ b/src/environment/testing/fake.ts
@@ -8,7 +8,7 @@ import {
 } from "../../storage/mute-configuration";
 
 export function buildTestingEnvironment() {
-  const store = mockStore();
+  const store = fakeStore();
   const githubLoader = jest.fn<
     Promise<LoadedState>,
     [string, LoadedState | null]
@@ -25,23 +25,31 @@ export function buildTestingEnvironment() {
   };
 }
 
-function mockStore() {
+function fakeStore() {
   return {
-    lastError: mockStorage<string | null>(null),
-    lastCheck: mockStorage<LoadedState | null>(null),
-    muteConfiguration: mockStorage<MuteConfiguration>(NOTHING_MUTED),
-    notifiedPullRequests: mockStorage<string[]>([]),
-    token: mockStorage<string | null>(null)
+    lastError: fakeStorage<string | null>(null),
+    lastCheck: fakeStorage<LoadedState | null>(null),
+    muteConfiguration: fakeStorage<MuteConfiguration>(NOTHING_MUTED),
+    notifiedPullRequests: fakeStorage<string[]>([]),
+    token: fakeStorage<string | null>(null)
   };
 }
 
-function mockStorage<T>(defaultValue: T) {
-  return {
-    load: jest
-      .fn<Promise<T>, []>()
-      .mockReturnValue(Promise.resolve(defaultValue)),
-    save: jest.fn<Promise<void>, []>()
+function fakeStorage<T>(defaultValue: T) {
+  const self = {
+    currentValue: defaultValue,
+    loadCount: 0,
+    saveCount: 0,
+    load: async () => {
+      self.loadCount++;
+      return self.currentValue;
+    },
+    save: async (value: T) => {
+      self.saveCount++;
+      self.currentValue = value;
+    }
   };
+  return self;
 }
 
 function fakeNotifier() {

--- a/src/notifications/api.ts
+++ b/src/notifications/api.ts
@@ -3,7 +3,7 @@ import { PullRequest } from "../storage/loaded-state";
 export interface Notifier {
   notify(
     unreviewedPullRequests: PullRequest[],
-    notifiedPullRequestUrls: Set<string>
+    alreadyNotifiedPullRequestUrls: Set<string>
   ): void;
   registerClickListener(): void;
 }

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -150,9 +150,40 @@ describe("Core", () => {
     expect(env.messenger.sent).toEqual([{ kind: "refresh" }]);
   });
 
-  it.todo("doesn't refresh when not authenticated");
+  it("doesn't refresh when not authenticated", async () => {
+    const env = buildTestingEnvironment();
+    const core = new Core(env);
+    env.store.token.currentValue = null;
+
+    // Initialise.
+    await core.load();
+    expect(core.refreshing).toBe(false);
+
+    // Refresh.
+    await core.refreshPullRequests();
+
+    expect(core.refreshing).toBe(false);
+    expect(core.lastError).toBeNull();
+  });
+
   it.todo("doesn't refresh when offline");
-  it.todo("updates badge when it starts refreshing");
+
+  it("updates badge when it starts refreshing", async () => {
+    const env = buildTestingEnvironment();
+    const core = new Core(env);
+    env.store.token.currentValue = "valid-token";
+
+    // Initialise.
+    await core.load();
+    expect(core.refreshing).toBe(false);
+    expect(env.badger.updated).toEqual([]);
+
+    // Refresh.
+    await core.refreshPullRequests();
+    expect(core.refreshing).toBe(true);
+    expect(env.badger.updated).toEqual([]);
+  });
+
   it.todo("updates badge and error when it finishes refreshing successfully");
   it.todo("updates badge and error when it fails to refresh");
   it.todo("notifies of new pull requests and saves notified state");

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -5,14 +5,14 @@ describe("Core", () => {
   it("loads without token", async () => {
     const env = buildTestingEnvironment();
     const core = new Core(env);
-    env.store.token.load.mockReturnValue(null);
+    env.store.token.load.mockReturnValue(Promise.resolve(null));
     await core.load();
   });
 
   it("loads with token", async () => {
     const env = buildTestingEnvironment();
     const core = new Core(env);
-    env.store.token.load.mockReturnValue("abc");
+    env.store.token.load.mockReturnValue(Promise.resolve("abc"));
     await core.load();
   });
 

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -1,20 +1,142 @@
 import { buildTestingEnvironment } from "../environment/testing/fake";
+import {
+  MuteConfiguration,
+  NOTHING_MUTED
+} from "../storage/mute-configuration";
 import { Core } from "./core";
 
 describe("Core", () => {
-  it("loads without token", async () => {
+  it("loads correctly without token", async () => {
     const env = buildTestingEnvironment();
     const core = new Core(env);
+
+    // No token stored.
     env.store.token.load.mockReturnValue(Promise.resolve(null));
+
+    // Other things are stored, they should be ignored.
+    env.store.lastError.load.mockReturnValue(Promise.resolve("error"));
+    env.store.lastCheck.load.mockReturnValue(
+      Promise.resolve({
+        userLogin: "fwouts",
+        repos: [],
+        openPullRequests: []
+      })
+    );
+    env.store.notifiedPullRequests.load.mockReturnValue(
+      Promise.resolve(["a", "b", "c"])
+    );
+    env.store.muteConfiguration.load.mockReturnValue(
+      Promise.resolve({
+        mutedPullRequests: [
+          {
+            repo: {
+              owner: "zenclabs",
+              name: "prmonitor"
+            },
+            number: 1,
+            until: {
+              kind: "next-update",
+              mutedAtTimestamp: 123
+            }
+          }
+        ]
+      })
+    );
+
+    // Initialise.
     await core.load();
+
+    expect(core.token).toBeNull();
+    expect(core.lastError).toBeNull();
+    expect(core.refreshing).toBe(false);
+    expect(core.loadedState).toBeNull();
+    expect(core.muteConfiguration).toEqual(NOTHING_MUTED);
+    expect(core.notifiedPullRequestUrls.size).toBe(0);
   });
 
   it("loads with token", async () => {
     const env = buildTestingEnvironment();
     const core = new Core(env);
-    env.store.token.load.mockReturnValue(Promise.resolve("abc"));
+
+    // No token stored.
+    env.store.token.load.mockReturnValue(Promise.resolve("valid-token"));
+
+    // Other things are stored, they should be restored.
+    const state = {
+      userLogin: "fwouts",
+      repos: [],
+      openPullRequests: []
+    };
+    const notifiedPullRequestUrls = ["a", "b", "c"];
+    const muteConfiguration: MuteConfiguration = {
+      mutedPullRequests: [
+        {
+          repo: {
+            owner: "zenclabs",
+            name: "prmonitor"
+          },
+          number: 1,
+          until: {
+            kind: "next-update",
+            mutedAtTimestamp: 123
+          }
+        }
+      ]
+    };
+    env.store.lastError.load.mockReturnValue(Promise.resolve("error"));
+    env.store.lastCheck.load.mockReturnValue(Promise.resolve(state));
+    env.store.notifiedPullRequests.load.mockReturnValue(
+      Promise.resolve(notifiedPullRequestUrls)
+    );
+    env.store.muteConfiguration.load.mockReturnValue(
+      Promise.resolve(muteConfiguration)
+    );
+
+    // Initialise.
     await core.load();
+
+    expect(core.token).toEqual("valid-token");
+    expect(core.lastError).toEqual("error");
+    expect(core.refreshing).toBe(false);
+    expect(core.loadedState).toEqual(state);
+    expect(core.muteConfiguration).toEqual(muteConfiguration);
+    expect(Array.from(core.notifiedPullRequestUrls)).toEqual(
+      notifiedPullRequestUrls
+    );
   });
+
+  it("reloads when receiving a load message", () => {
+    const env = buildTestingEnvironment();
+
+    // Initialize the core.
+    // TODO: Consider adding the listener in a separate init() method.
+    new Core(env);
+    env.messenger.trigger({
+      kind: "reload"
+    });
+    expect(env.store.token.load).toHaveBeenCalled();
+  });
+
+  it("doesn't reload on non-reload message", () => {
+    const env = buildTestingEnvironment();
+
+    // Initialize the core.
+    // TODO: Consider adding the listener in a separate init() method.
+    new Core(env);
+    env.messenger.trigger({
+      kind: "refresh"
+    });
+    expect(env.store.token.load).not.toHaveBeenCalled();
+  });
+
+  it.todo("resets state and triggers a refresh when a new token is set");
+  it.todo("doesn't refresh when not authenticated");
+  it.todo("doesn't refresh when offline");
+  it.todo("updates badge when it starts refreshing");
+  it.todo("updates badge and error when it finishes refreshing successfully");
+  it.todo("updates badge and error when it fails to refresh");
+  it.todo("notifies of new pull requests and saves notified state");
+  it.todo("updates badge after muting a PR");
 
   it("doesn't duplicate muted pull requests", async () => {
     const env = buildTestingEnvironment();

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -129,7 +129,32 @@ describe("Core", () => {
     expect(env.store.token.load).not.toHaveBeenCalled();
   });
 
-  it.todo("resets state and triggers a refresh when a new token is set");
+  it("resets state and triggers a refresh when a new token is set", async () => {
+    const env = buildTestingEnvironment();
+    const core = new Core(env);
+
+    // A valid token is stored.
+    env.store.token.load.mockReturnValue(Promise.resolve("token-fwouts"));
+    const state = {
+      userLogin: "fwouts",
+      repos: [],
+      openPullRequests: []
+    };
+    env.store.lastCheck.load.mockReturnValue(Promise.resolve(state));
+
+    // Initialise.
+    await core.load();
+    expect(core.loadedState && core.loadedState.userLogin).toBe("fwouts");
+
+    await core.setNewToken("token-kevin");
+    expect(env.store.token.save).toBeCalledWith("token-kevin");
+    expect(env.store.lastError.save).toBeCalledWith(null);
+    expect(env.store.notifiedPullRequests.save).toBeCalledWith([]);
+    expect(env.store.lastCheck.save).toBeCalledWith(null);
+    expect(env.store.muteConfiguration.save).toBeCalledWith(NOTHING_MUTED);
+    expect(env.messenger.sent).toEqual([{ kind: "refresh" }]);
+  });
+
   it.todo("doesn't refresh when not authenticated");
   it.todo("doesn't refresh when offline");
   it.todo("updates badge when it starts refreshing");

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -58,7 +58,7 @@ describe("Core", () => {
     const env = buildTestingEnvironment();
     const core = new Core(env);
 
-    // No token stored.
+    // A valid token is stored.
     env.store.token.load.mockReturnValue(Promise.resolve("valid-token"));
 
     // Other things are stored, they should be restored.

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -28,15 +28,16 @@ export class Core {
 
   async load() {
     this.token = await this.env.store.token.load();
-    this.lastError = await this.env.store.lastError.load();
     this.overallStatus = "loading";
     if (this.token !== null) {
+      this.lastError = await this.env.store.lastError.load();
       this.loadedState = await this.env.store.lastCheck.load();
       this.notifiedPullRequestUrls = new Set(
         await this.env.store.notifiedPullRequests.load()
       );
       this.muteConfiguration = await this.env.store.muteConfiguration.load();
     } else {
+      this.lastError = null;
       this.token = null;
       this.loadedState = null;
       this.notifiedPullRequestUrls = new Set();

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -79,13 +79,13 @@ export class Core {
         this.notifiedPullRequestUrls
       );
       await this.saveNotifiedPullRequests(unreviewedPullRequests);
-      this.updateBadge();
       this.saveError(null);
     } catch (e) {
       this.saveError(e.message);
       throw e;
     } finally {
       this.refreshing = false;
+      this.updateBadge();
       this.triggerReload();
     }
   }
@@ -141,7 +141,6 @@ export class Core {
   private async saveError(error: string | null) {
     this.lastError = error;
     await this.env.store.lastError.save(error);
-    this.updateBadge();
   }
 
   private async saveLoadedState(lastCheck: LoadedState | null) {


### PR DESCRIPTION
This also fixes two suboptimal behaviours (unlikely to result in real bugs in practice):
- when there is no token, we shouldn't show an error from a previously signed in user
- updateBadge() was called twice unnecessarily (from both refreshPullRequests and saveError)