### PR TITLE
Reuse existing tab when a PR is already open

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "PR Monitor",
   "version": "0.2.6",
   "description": "Get notified when you receive a pull request on GitHub.",
-  "permissions": ["alarms", "notifications", "storage"],
+  "permissions": ["alarms", "notifications", "storage", "tabs"],
   "background": {
     "scripts": ["background.js"],
     "persistent": true

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,10 +16,9 @@ function setUpBackgroundScript(chromeApi: ChromeApi, env: Environment) {
   refreshOnUpdate(chromeApi, triggerRefresh);
   refreshRegulary(chromeApi, triggerRefresh);
   refreshOnDemand(env.messenger, triggerRefresh);
-  env.notifier.registerClickListener();
+  const core = new Core(env);
 
   async function triggerRefresh() {
-    const core = new Core(env);
     await core.load();
     if (!core.token) {
       return;

--- a/src/chrome/fake-chrome.ts
+++ b/src/chrome/fake-chrome.ts
@@ -32,6 +32,11 @@ export const fakeChrome = (<Partial<ChromeApi>>{
       options: chrome.notifications.NotificationOptions
     ) {
       console.log("chrome.notifications.create", notificationId, options);
+    },
+    onClicked: {
+      addListener(listener: any) {
+        console.log("chrome.notifications.onClicked.addListener", listener);
+      }
     }
   },
   storage: {
@@ -53,6 +58,11 @@ export const fakeChrome = (<Partial<ChromeApi>>{
           }, {})
         );
       }
+    }
+  },
+  tabs: {
+    query(_queryInfo, callback) {
+      callback([]);
     }
   }
 }) as ChromeApi;

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -31,6 +31,7 @@ export class Popup extends Component<PopupProps> {
             ) : (
               <PullRequestList
                 pullRequests={this.props.core.unreviewedPullRequests}
+                onOpen={this.onOpen}
                 onMute={this.onMute}
               />
             )}
@@ -42,6 +43,10 @@ export class Popup extends Component<PopupProps> {
       </>
     );
   }
+
+  private onOpen = (pullRequestUrl: string) => {
+    this.props.core.openPullRequest(pullRequestUrl);
+  };
 
   private onMute = (pullRequest: PullRequest) => {
     if (

--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -7,6 +7,7 @@ import { SmallButton } from "./design/Button";
 
 export interface PullRequestItemProps {
   pullRequest: PullRequest;
+  onOpen(pullRequestUrl: string): void;
   onMute(pullRequest: PullRequest): void;
 }
 
@@ -16,6 +17,7 @@ const PullRequestBox = styled.a`
   justify-content: space-between;
   text-decoration: none;
   border-bottom: 1px solid #eee;
+  cursor: pointer;
 
   &:last-child {
     border-bottom: none;
@@ -78,11 +80,7 @@ const AuthorLogin = styled.div`
 export class PullRequestItem extends Component<PullRequestItemProps> {
   render() {
     return (
-      <PullRequestBox
-        key={this.props.pullRequest.nodeId}
-        target="_blank"
-        href={this.props.pullRequest.htmlUrl}
-      >
+      <PullRequestBox key={this.props.pullRequest.nodeId} onClick={this.open}>
         <Info>
           <Title>
             {this.props.pullRequest.title}
@@ -106,8 +104,14 @@ export class PullRequestItem extends Component<PullRequestItemProps> {
     );
   }
 
+  private open = (e: React.MouseEvent) => {
+    this.props.onOpen(this.props.pullRequest.htmlUrl);
+    e.preventDefault();
+  };
+
   private mute = (e: React.MouseEvent) => {
     this.props.onMute(this.props.pullRequest);
     e.preventDefault();
+    e.stopPropagation();
   };
 }

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -7,6 +7,7 @@ import { PullRequestItem } from "./PullRequestItem";
 
 export interface PullRequestListProps {
   pullRequests: PullRequest[];
+  onOpen(pullRequestUrl: string): void;
   onMute(pullRequest: PullRequest): void;
 }
 
@@ -21,6 +22,7 @@ export class PullRequestList extends Component<PullRequestListProps> {
           <PullRequestItem
             key={pullRequest.nodeId}
             pullRequest={pullRequest}
+            onOpen={this.props.onOpen}
             onMute={this.props.onMute}
           />
         ))}

--- a/src/environment/api.ts
+++ b/src/environment/api.ts
@@ -3,6 +3,7 @@ import { GitHubLoader } from "../loading/api";
 import { CrossScriptMessenger } from "../messaging/api";
 import { Notifier } from "../notifications/api";
 import { Store } from "../storage/api";
+import { TabOpener } from "../tabs/api";
 
 export interface Environment {
   store: Store;
@@ -10,5 +11,6 @@ export interface Environment {
   notifier: Notifier;
   badger: Badger;
   messenger: CrossScriptMessenger;
+  tabOpener: TabOpener;
   isOnline(): boolean;
 }

--- a/src/environment/implementation.ts
+++ b/src/environment/implementation.ts
@@ -4,6 +4,7 @@ import { buildGitHubLoader } from "../loading/github-loader";
 import { buildMessenger } from "../messaging/implementation";
 import { buildNotifier } from "../notifications/implementation";
 import { buildStore } from "../storage/implementation";
+import { buildTabOpener } from "../tabs/implementation";
 import { Environment } from "./api";
 
 export function buildEnvironment(chromeApi: ChromeApi): Environment {
@@ -13,6 +14,7 @@ export function buildEnvironment(chromeApi: ChromeApi): Environment {
     notifier: buildNotifier(chromeApi),
     badger: buildBadger(chromeApi),
     messenger: buildMessenger(chromeApi),
+    tabOpener: buildTabOpener(chromeApi),
     isOnline: () => navigator.onLine
   };
 }

--- a/src/notifications/api.ts
+++ b/src/notifications/api.ts
@@ -5,5 +5,7 @@ export interface Notifier {
     unreviewedPullRequests: PullRequest[],
     alreadyNotifiedPullRequestUrls: Set<string>
   ): void;
-  registerClickListener(): void;
+  registerClickListener(clickListener: NotifierClickListener): void;
 }
+
+export type NotifierClickListener = (pullRequestUrl: string) => void;

--- a/src/notifications/implementation.ts
+++ b/src/notifications/implementation.ts
@@ -11,10 +11,12 @@ export function buildNotifier(chromeApi: ChromeApi): Notifier {
         notifiedPullRequestUrls
       );
     },
-    registerClickListener() {
-      chromeApi.notifications.onClicked.addListener(notificationId =>
-        onNotificationClicked(chromeApi, notificationId)
-      );
+    registerClickListener(clickListener: (pullRequestUrl: string) => void) {
+      // Notification IDs are always pull request URLs (see below).
+      chromeApi.notifications.onClicked.addListener(notificationId => {
+        clickListener(notificationId);
+        chromeApi.notifications.clear(notificationId);
+      });
     }
   };
 }
@@ -60,10 +62,4 @@ function showNotification(chromeApi: ChromeApi, pullRequest: PullRequest) {
     message: pullRequest.title,
     ...(supportsRequireInteraction ? { requireInteraction: true } : {})
   });
-}
-
-function onNotificationClicked(chromeApi: ChromeApi, notificationId: string) {
-  // Notification IDs are always pull request URLs (see above).
-  window.open(notificationId);
-  chromeApi.notifications.clear(notificationId);
 }

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -1,6 +1,9 @@
 import { buildTestingEnvironment } from "../environment/testing/fake";
 import { LoadedState } from "../storage/loaded-state";
-import { MuteConfiguration, NOTHING_MUTED } from "../storage/mute-configuration";
+import {
+  MuteConfiguration,
+  NOTHING_MUTED
+} from "../storage/mute-configuration";
 import { Core } from "./core";
 
 describe("Core", () => {

--- a/src/state/core.spec.ts
+++ b/src/state/core.spec.ts
@@ -1,9 +1,6 @@
 import { buildTestingEnvironment } from "../environment/testing/fake";
 import { LoadedState } from "../storage/loaded-state";
-import {
-  MuteConfiguration,
-  NOTHING_MUTED
-} from "../storage/mute-configuration";
+import { MuteConfiguration, NOTHING_MUTED } from "../storage/mute-configuration";
 import { Core } from "./core";
 
 describe("Core", () => {
@@ -122,6 +119,27 @@ describe("Core", () => {
       kind: "refresh"
     });
     expect(env.store.token.loadCount).toBe(0);
+  });
+
+  it("opens the pull request when notification is clicked", () => {
+    const env = buildTestingEnvironment();
+
+    // Initialize the core.
+    // TODO: Consider adding the listener in a separate init() method.
+    new Core(env);
+
+    env.notifier.simulateClick("http://some-pr");
+    expect(env.tabOpener.openedUrls).toEqual(["http://some-pr"]);
+  });
+
+  it("opens the pull request when openPullRequest() is called", () => {
+    const env = buildTestingEnvironment();
+
+    // Initialize the core.
+    const core = new Core(env);
+
+    core.openPullRequest("http://some-pr");
+    expect(env.tabOpener.openedUrls).toEqual(["http://some-pr"]);
   });
 
   it("resets state and triggers a refresh when a new token is set", async () => {

--- a/src/state/core.ts
+++ b/src/state/core.ts
@@ -24,6 +24,7 @@ export class Core {
         this.load();
       }
     });
+    this.env.notifier.registerClickListener(url => this.openPullRequest(url));
   }
 
   async load() {
@@ -88,6 +89,10 @@ export class Core {
       this.updateBadge();
       this.triggerReload();
     }
+  }
+
+  openPullRequest(pullRequestUrl: string) {
+    this.env.tabOpener.openPullRequest(pullRequestUrl);
   }
 
   async mutePullRequest(pullRequest: {

--- a/src/tabs/api.ts
+++ b/src/tabs/api.ts
@@ -1,0 +1,6 @@
+/**
+ * TabOpener opens tabs intelligently (reusing them when possible).
+ */
+export interface TabOpener {
+  openPullRequest(pullRequestUrl: string): void;
+}

--- a/src/tabs/implementation.ts
+++ b/src/tabs/implementation.ts
@@ -1,0 +1,21 @@
+import { ChromeApi } from "../chrome/api";
+import { TabOpener } from "./api";
+
+export function buildTabOpener(chromeApi: ChromeApi): TabOpener {
+  return {
+    openPullRequest(pullRequestUrl: string) {
+      chromeApi.tabs.query({}, tabs => {
+        const existingTab = tabs.find(tab =>
+          tab.url ? tab.url.startsWith(pullRequestUrl) : false
+        );
+        if (existingTab) {
+          chromeApi.tabs.highlight({
+            tabs: existingTab.index
+          });
+        } else {
+          window.open(pullRequestUrl);
+        }
+      });
+    }
+  };
+}


### PR DESCRIPTION
This involves adding a TabOpener, which is in charge of finding a tab to reuse, otherwise opening a new one.

This fixes #126, but requires adding a new permission to access tabs.