### PR TITLE
Trigger release builds on tag on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             - node_modules
           key: v3-dependencies-{{ checksum "package.json" }}
       - run: yarn build
+      - run: sed -e "s/0\.0\.0/$(echo $CIRCLE_TAG | tail -c +2)/" manifest.json > dist/manifest.json
       - run: cd dist && zip extension.zip -r *
       - store_artifacts:
           path: dist/extension.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,36 @@ jobs:
           name: Prettier
           command: |
             yarn prettier --list-different "**/*.js" "**/*.jsx" "**/*.ts" "**/*.tsx"
+  build-release:
+    docker:
+      - image: circleci/node
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "package.json" }}
+            - v3-dependencies-
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - node_modules
+          key: v3-dependencies-{{ checksum "package.json" }}
+      - run: yarn build
+      - run: cd dist && zip extension.zip -r *
+      - store_artifacts:
+          path: dist/extension.zip
 workflows:
   build_and_test:
     jobs:
       - build
       - test
       - prettier
+  release:
+    jobs:
+      - build-release:
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PR Monitor",
-  "version": "0.2.6",
+  "version": "0.0.0",
   "description": "Get notified when you receive a pull request on GitHub.",
   "permissions": ["alarms", "notifications", "storage", "tabs"],
   "background": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "start": "webpack-dev-server --open",
     "watch": "tsc --noEmit --watch",
-    "build": "rm -rf dist; webpack --mode production && cd dist && zip extension.zip -r *",
+    "build": "rm -rf dist; webpack --mode production",
     "test": "jest",
     "prettier:fix": "prettier --write \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\""
   }


### PR DESCRIPTION
This will prevent issues such as forgetting to run `yarn install` after an update from dependabot.