### PR TITLE
Focus to the right window

### DIFF
--- a/src/tabs/implementation.ts
+++ b/src/tabs/implementation.ts
@@ -41,8 +41,10 @@ function openTab(
       );
       if (existingTab) {
         chromeApi.tabs.highlight({
+          windowId: existingTab.windowId,
           tabs: existingTab.index
         });
+        chromeApi.windows.update(existingTab.windowId, {focused: true});
       } else {
         chrome.tabs.create({
           url: pullRequestUrl

--- a/src/tabs/implementation.ts
+++ b/src/tabs/implementation.ts
@@ -44,7 +44,7 @@ function openTab(
           windowId: existingTab.windowId,
           tabs: existingTab.index
         });
-        chromeApi.windows.update(existingTab.windowId, {focused: true});
+        chromeApi.windows.update(existingTab.windowId, { focused: true });
       } else {
         chrome.tabs.create({
           url: pullRequestUrl


### PR DESCRIPTION
When clicking on a PR that's already opened in a tab, make sure we also switch (focus) to the correct window.

Without this, if the PR is already opened in another window, clicking on it will appear to do nothing, see  #126.