### PR TITLE
Fix clicking on PRs in development mode

### DIFF
--- a/src/chrome/fake-chrome.ts
+++ b/src/chrome/fake-chrome.ts
@@ -77,5 +77,10 @@ export const fakeChrome = (<Partial<ChromeApi>>{
     create(properties) {
       window.open(properties.url);
     }
+  },
+  windows: {
+    update(windowId, updateInfo) {
+      console.log("chrome.windows.update", windowId, updateInfo);
+    }
   }
 }) as ChromeApi;

--- a/src/tabs/implementation.ts
+++ b/src/tabs/implementation.ts
@@ -46,13 +46,13 @@ function openTab(
         });
         chromeApi.windows.update(existingTab.windowId, { focused: true });
       } else {
-        chrome.tabs.create({
+        chromeApi.tabs.create({
           url: pullRequestUrl
         });
       }
     });
   } else {
-    chrome.tabs.create({
+    chromeApi.tabs.create({
       url: pullRequestUrl
     });
   }


### PR DESCRIPTION
This was broken because:
- we were using `chrome` instead of `chromeApi`
- the fake Chrome API had to implement windows.update()