### PR TITLE
Ignore testing directory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,5 +59,5 @@
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "exclude": ["**/*.spec.ts"]
+  "exclude": ["**/*.spec.ts", "**/testing/*.ts"]
 }


### PR DESCRIPTION
This should allow the migration to ts-loader 6.0.