### PR TITLE
Use a dark grey instead of green badge when no PRs need to be reviewed

### DIFF
--- a/src/badge/implementation.ts
+++ b/src/badge/implementation.ts
@@ -36,7 +36,7 @@ function badgeColor(state: BadgeState): string {
       return "#48f";
     case "loaded":
     case "reloading":
-      return state.unreviewedPullRequestCount === 0 ? "#4d4" : "#f00";
+      return state.unreviewedPullRequestCount === 0 ? "#000000d9" : "#f00";
     case "error":
       return "#000";
   }


### PR DESCRIPTION
Fixes #225.

This was picked to match Firefox's default (Chrome's is not documented): https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor