### PR TITLE
Remove optimisation to avoid loading comments and reviews unnecessarily

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -68,7 +68,7 @@ function refreshRegulary(
   triggerRefresh: () => Promise<void>
 ) {
   chromeApi.alarms.create({
-    periodInMinutes: 1
+    periodInMinutes: 3
   });
   chromeApi.alarms.onAlarm.addListener(alarm => {
     console.debug("Alarm triggered", alarm);

--- a/src/loading/implementation.ts
+++ b/src/loading/implementation.ts
@@ -7,17 +7,10 @@ export function buildGitHubLoader(): GitHubLoader {
   return load;
 }
 
-async function load(
-  token: string,
-  lastCheck: LoadedState | null
-): Promise<LoadedState> {
+async function load(token: string): Promise<LoadedState> {
   const githubApi = buildGitHubApi(token);
   const user = await githubApi.loadAuthenticatedUser();
-  const openPullRequests = await refreshOpenPullRequests(
-    githubApi,
-    user.login,
-    lastCheck
-  );
+  const openPullRequests = await refreshOpenPullRequests(githubApi, user.login);
   return {
     userLogin: user.login,
     openPullRequests

--- a/src/loading/internal/pull-requests.spec.ts
+++ b/src/loading/internal/pull-requests.spec.ts
@@ -17,7 +17,7 @@ describe("refreshOpenPullRequests", () => {
   it("returns an empty list when there are no PRs", async () => {
     const githubApi = mockGitHubApi();
     githubApi.searchPullRequests.mockReturnValue(Promise.resolve([]));
-    const result = await refreshOpenPullRequests(githubApi, "author", null);
+    const result = await refreshOpenPullRequests(githubApi, "author");
     expect(result).toHaveLength(0);
   });
 
@@ -81,10 +81,7 @@ describe("refreshOpenPullRequests", () => {
     githubApi.loadComments.mockReturnValue(Promise.resolve([]));
     githubApi.loadReviews.mockReturnValue(Promise.resolve([]));
     githubApi.loadCommits.mockReturnValue(Promise.resolve([]));
-    const result = await refreshOpenPullRequests(githubApi, "author", {
-      userLogin: "author",
-      openPullRequests: [createFakePullRequest("zenclabs", "prmonitor", 1)]
-    });
+    const result = await refreshOpenPullRequests(githubApi, "author");
     expect(result).toHaveLength(3);
     expect(githubApi.searchPullRequests.mock.calls).toEqual([
       [`review-requested:author is:open archived:false`],


### PR DESCRIPTION
GitHub API's behaviour seems to have changed in the last week. Before, a PR's updated_at field would change whenever a comment or review was posted. This no longer seems to be the case, which means that our previous optimisation to skip reloading comments and reviews is now incorrect.

This also changes the refresh rate back to every 3 minutes, to reduce the chances of getting rate limited.

On the bright side, the code is now simpler :)