### PR TITLE
Sort PRs by most recent first

### DIFF
--- a/src/filtering/muted.ts
+++ b/src/filtering/muted.ts
@@ -1,6 +1,6 @@
 import { PullRequest } from "../storage/loaded-state";
 import { MuteConfiguration } from "../storage/mute-configuration";
-import { getLastChangeTimestamp } from "./timestamps";
+import { getLastAuthorUpdateTimestamp } from "./timestamps";
 
 /**
  * Returns whether the pull request is muted.
@@ -16,7 +16,7 @@ export function isMuted(pr: PullRequest, muteConfiguration: MuteConfiguration) {
       switch (muted.until.kind) {
         case "next-update":
           const updatedSince =
-            getLastChangeTimestamp(pr) > muted.until.mutedAtTimestamp;
+            getLastAuthorUpdateTimestamp(pr) > muted.until.mutedAtTimestamp;
           return !updatedSince;
       }
     }

--- a/src/filtering/timestamps.ts
+++ b/src/filtering/timestamps.ts
@@ -1,7 +1,10 @@
 import { PullRequest } from "../storage/loaded-state";
 
 export function getLastUpdateTimestamp(pr: PullRequest) {
-  let prTimestamp = new Date(pr.updatedAt).getTime();
+  let prTimestamp = Math.max(
+    new Date(pr.updatedAt).getTime(),
+    getLastCommitTimestamp(pr)
+  );
   for (const comment of pr.comments) {
     prTimestamp = Math.max(prTimestamp, new Date(comment.createdAt).getTime());
   }

--- a/src/filtering/timestamps.ts
+++ b/src/filtering/timestamps.ts
@@ -1,6 +1,17 @@
 import { PullRequest } from "../storage/loaded-state";
 
-export function getLastChangeTimestamp(pr: PullRequest): number {
+export function getLastUpdateTimestamp(pr: PullRequest) {
+  let prTimestamp = new Date(pr.updatedAt).getTime();
+  for (const comment of pr.comments) {
+    prTimestamp = Math.max(prTimestamp, new Date(comment.createdAt).getTime());
+  }
+  for (const review of pr.reviews) {
+    prTimestamp = Math.max(prTimestamp, new Date(review.submittedAt).getTime());
+  }
+  return prTimestamp;
+}
+
+export function getLastAuthorUpdateTimestamp(pr: PullRequest): number {
   return Math.max(
     getLastAuthorCommentTimestamp(pr),
     getLastCommitTimestamp(pr)

--- a/src/github-api/implementation.ts
+++ b/src/github-api/implementation.ts
@@ -18,9 +18,7 @@ export function buildGitHubApi(token: string): GitHubApi {
     searchPullRequests(query) {
       return octokit.paginate(
         octokit.search.issuesAndPullRequests.endpoint.merge({
-          q: `is:pr ${query}`,
-          sort: "updated",
-          order: "desc"
+          q: `is:pr ${query}`
         })
       );
     },

--- a/src/loading/implementation.ts
+++ b/src/loading/implementation.ts
@@ -1,5 +1,5 @@
 import { buildGitHubApi } from "../github-api/implementation";
-import { LoadedState } from "../storage/loaded-state";
+import { LoadedState, PullRequest } from "../storage/loaded-state";
 import { GitHubLoader } from "./api";
 import { refreshOpenPullRequests } from "./internal/pull-requests";
 
@@ -11,8 +11,22 @@ async function load(token: string): Promise<LoadedState> {
   const githubApi = buildGitHubApi(token);
   const user = await githubApi.loadAuthenticatedUser();
   const openPullRequests = await refreshOpenPullRequests(githubApi, user.login);
+  const sorted = [...openPullRequests].sort((a, b) => {
+    return getPullRequestTimestamp(b) - getPullRequestTimestamp(a);
+  });
   return {
     userLogin: user.login,
-    openPullRequests
+    openPullRequests: sorted
   };
+}
+
+function getPullRequestTimestamp(pr: PullRequest) {
+  let prTimestamp = new Date(pr.updatedAt).getTime();
+  for (const comment of pr.comments) {
+    prTimestamp = Math.max(prTimestamp, new Date(comment.createdAt).getTime());
+  }
+  for (const review of pr.reviews) {
+    prTimestamp = Math.max(prTimestamp, new Date(review.submittedAt).getTime());
+  }
+  return prTimestamp;
 }

--- a/src/loading/implementation.ts
+++ b/src/loading/implementation.ts
@@ -1,5 +1,6 @@
+import { getLastUpdateTimestamp } from "../filtering/timestamps";
 import { buildGitHubApi } from "../github-api/implementation";
-import { LoadedState, PullRequest } from "../storage/loaded-state";
+import { LoadedState } from "../storage/loaded-state";
 import { GitHubLoader } from "./api";
 import { refreshOpenPullRequests } from "./internal/pull-requests";
 
@@ -12,21 +13,10 @@ async function load(token: string): Promise<LoadedState> {
   const user = await githubApi.loadAuthenticatedUser();
   const openPullRequests = await refreshOpenPullRequests(githubApi, user.login);
   const sorted = [...openPullRequests].sort((a, b) => {
-    return getPullRequestTimestamp(b) - getPullRequestTimestamp(a);
+    return getLastUpdateTimestamp(b) - getLastUpdateTimestamp(a);
   });
   return {
     userLogin: user.login,
     openPullRequests: sorted
   };
-}
-
-function getPullRequestTimestamp(pr: PullRequest) {
-  let prTimestamp = new Date(pr.updatedAt).getTime();
-  for (const comment of pr.comments) {
-    prTimestamp = Math.max(prTimestamp, new Date(comment.createdAt).getTime());
-  }
-  for (const review of pr.reviews) {
-    prTimestamp = Math.max(prTimestamp, new Date(review.submittedAt).getTime());
-  }
-  return prTimestamp;
 }

--- a/src/storage/loaded-state.ts
+++ b/src/storage/loaded-state.ts
@@ -38,10 +38,6 @@ export interface PullRequest {
   repoOwner: string;
   repoName: string;
   pullRequestNumber: number;
-  /**
-   * The last time the PR has been updated. This changes every time a new review
-   * or comment is added, so when it doesn't change, we know not to reload them.
-   */
   updatedAt: string;
   author: {
     login: string;


### PR DESCRIPTION
Until now, we were relying on GitHub's sorting for PRs, via the following query:
```typescript
        octokit.search.issuesAndPullRequests.endpoint.merge({
          q: `is:pr ${query}`,
          sort: "updated",
          order: "desc"
        })
```

However, this didn't always result in the expected order of PRs. For example, when someone posts a comment on a PR, it doesn't seem to bump it up in the list.

This replaces the sorting logic by manually sorting PRs instead, taking into account all comments, commits and reviews.